### PR TITLE
Remove duplicate gradle plugin application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 apply plugin: 'application'
-apply plugin: 'me.champeau.gradle.jmh'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 


### PR DESCRIPTION
A plugin declared in the "plugins { }" block will also be applied. An
additional "apply plugin" call is unnecessary.
