### PR TITLE
Refactor CLI and corresponding tests to be more straight forward

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     testCompile 'com.pholser:junit-quickcheck-core:0.6.1'
     testCompile 'com.pholser:junit-quickcheck-generators:0.6.1'
     testCompile 'junit:junit:4.12'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
+    testCompile 'com.google.jimfs:jimfs:1.1'
 }
 
 tasks.test.dependsOn installDist

--- a/src/main/java/minijava/InvalidCommandLineArguments.java
+++ b/src/main/java/minijava/InvalidCommandLineArguments.java
@@ -1,9 +1,0 @@
-package minijava;
-
-/** Thrown for invalid command line arguments. */
-public class InvalidCommandLineArguments extends Exception {
-
-  public InvalidCommandLineArguments(String message) {
-    super(message);
-  }
-}

--- a/src/main/java/minijava/Main.java
+++ b/src/main/java/minijava/Main.java
@@ -1,15 +1,12 @@
 package minijava;
 
+import java.nio.file.FileSystems;
+
 public class Main {
   public static void main(String[] args) {
     //new LexerRepl(SimpleLexer::new).run(); //← to test the lexer
-    try {
-      System.exit(Cli.create(System.out, System.err, args).run());
-    } catch (InvalidCommandLineArguments invEx) {
-      System.err.println(invEx.getMessage());
-      System.err.println();
-      System.err.println(Cli.getUsageInfo());
-      System.exit(1);
-    }
+    Cli cli = new Cli(System.out, System.err, FileSystems.getDefault());
+    int status = cli.run(args);
+    System.exit(status);
   }
 }


### PR DESCRIPTION
I tried to clarify and simplify things. The ugly parts (that deal with
the JCommander library) were moved into a separate class.

Blackbox tests that use the ./run script were removed. We have the
python based test suites for that. Some other tests for command line
options validation were added.

I'm not sure why the outputLexerTokens method was so complicated before,
I hope I didn't miss something?!
