### PR TITLE
Added mjtest as a submodule tracking master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "mjtest"]
+	path = mjtest
+	url = https://github.com/mj3-16/mjtest
+	branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: java
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 jdk:
   - oraclejdk8
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,20 @@
 language: java
+
+# installing python3
+
+addons:
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - python3.5 # for mjtest, no less than 3.5...
+before_install:
+  - echo $PATH
+  - sudo rm -f /usr/bin/python3 # whatever
+  - sudo ln -s /usr/bin/python3.5 /usr/bin/python3
+
+# caching
+
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -6,6 +22,9 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+# actual build stuff
+
 jdk:
   - oraclejdk8
 env:

--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,12 @@ task astTest(type: Exec) {
     commandLine 'python3', './mjt.py', 'ast', '../run'
 }
 
-tasks.test.dependsOn installDist
 tasks.check.dependsOn syntaxTest
 tasks.check.dependsOn astTest
+
+tasks.test.dependsOn installDist
+tasks.syntaxTest.dependsOn installDist
+tasks.astTest.dependsOn installDist
 
 task installGitHooks(type: Copy) {
     from file('git-hooks/pre-commit')

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,19 @@ dependencies {
     testCompile 'com.google.jimfs:jimfs:1.1'
 }
 
+task syntaxTest(type: Exec) {
+    workingDir './mjtest'
+    commandLine 'python3', './mjt.py', 'syntax', '../run'
+}
+
+task astTest(type: Exec) {
+    workingDir './mjtest'
+    commandLine 'python3', './mjt.py', 'ast', '../run'
+}
+
 tasks.test.dependsOn installDist
+tasks.check.dependsOn syntaxTest
+tasks.check.dependsOn astTest
 
 task installGitHooks(type: Copy) {
     from file('git-hooks/pre-commit')

--- a/src/main/java/minijava/lexer/SimpleLexer.java
+++ b/src/main/java/minijava/lexer/SimpleLexer.java
@@ -264,7 +264,7 @@ public class SimpleLexer implements Lexer {
     while (true) {
       byte cur = input.current();
       byte next = input.next();
-      if (cur <= 0 || next <= 0) {
+      if (cur < 0 || next < 0) {
         throw createError();
       }
       if (cur == '*' && next == '/') {

--- a/src/main/java/minijava/parser/Parser.java
+++ b/src/main/java/minijava/parser/Parser.java
@@ -41,6 +41,10 @@ public class Parser {
     consumeToken();
   }
 
+  private void unexpectCurrentToken() {
+    throw new ParserError(Thread.currentThread().getStackTrace()[2].getMethodName(), currentToken);
+  }
+
   private boolean isCurrentTokenTypeOf(Terminal terminal) {
     if (currentToken.isTerminal(terminal)) {
       return true;
@@ -198,6 +202,8 @@ public class Parser {
       case IDENT:
         expectAndConsume(IDENT);
         break;
+      default:
+        unexpectCurrentToken();
     }
   }
 
@@ -354,6 +360,8 @@ public class Parser {
       case LBRACKET:
         parseArrayAccess();
         break;
+      default:
+        unexpectCurrentToken();
     }
   }
 
@@ -383,7 +391,7 @@ public class Parser {
 
   /** Arguments -> (Expression (,Expression)*)? */
   private void parseArguments() {
-    if (isCurrentTokenNotTypeOf(RBRACKET)) {
+    if (isCurrentTokenNotTypeOf(RPAREN)) {
       parseExpression();
       while (isCurrentTokenTypeOf(COMMA) && isCurrentTokenNotTypeOf(EOF)) {
         expectAndConsume(COMMA);
@@ -429,6 +437,8 @@ public class Parser {
       case NEW:
         parseNewObjectArrayExpression();
         break;
+      default:
+        unexpectCurrentToken();
     }
   }
 
@@ -459,6 +469,8 @@ public class Parser {
             break;
         }
         break;
+      default:
+        unexpectCurrentToken();
     }
   }
 

--- a/src/main/java/minijava/parser/ParserError.java
+++ b/src/main/java/minijava/parser/ParserError.java
@@ -24,4 +24,11 @@ class ParserError extends MJError {
             "Parser error at %s parsed via %s: expected %s with value '%s' but got %s",
             actualToken.position, rule, expectedTerminal, expectedValue, actualToken));
   }
+
+  ParserError(String rule, Token unexpectedToken) {
+    super(
+        String.format(
+            "Parser error at %s parsed via %s: unexpected %s with value '%s'",
+            unexpectedToken.position, rule, unexpectedToken.terminal, unexpectedToken.lexval));
+  }
 }


### PR DESCRIPTION
Also modified build.gradle so that it will invoke mjt.py ast and syntax tests as part of `gradle check`.

The tests currently don't exit successfully, so we should probably wait until the fixes in the parser land.