### PR TITLE
Git add after formatting in pre-commit hook

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -3,3 +3,4 @@
 # Format code using google-java-format
 echo "pre-commit code format"
 ./gradlew googleJavaFormat
+git add `git diff --cached --name-only`


### PR DESCRIPTION
git adding previously added files again in the pre-commit hook, so that the work done by googleJavaFormat is also committed.

Don't forget to `gradle installGitHooks` again after this change!