### PR TITLE
Make AST visitors more flexible by using wildcards

### DIFF
--- a/src/main/java/minijava/ast/Block.java
+++ b/src/main/java/minijava/ast/Block.java
@@ -11,7 +11,7 @@ public class Block<TRef> implements Statement<TRef> {
   }
 
   @Override
-  public <TRet> TRet acceptVisitor(Statement.Visitor<TRef, TRet> visitor) {
+  public <TRet> TRet acceptVisitor(Statement.Visitor<? super TRef, TRet> visitor) {
     return visitor.visitBlock(this);
   }
 }

--- a/src/main/java/minijava/ast/BlockStatement.java
+++ b/src/main/java/minijava/ast/BlockStatement.java
@@ -1,7 +1,7 @@
 package minijava.ast;
 
 public interface BlockStatement<TRef> {
-  <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor);
+  <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor);
 
   class Variable<TRef> implements BlockStatement<TRef> {
     public final Type<TRef> type;
@@ -15,13 +15,13 @@ public interface BlockStatement<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitVariable(this);
     }
   }
 
   interface Visitor<TRef, TRet> extends Statement.Visitor<TRef, TRet> {
 
-    TRet visitVariable(Variable<TRef> that);
+    TRet visitVariable(Variable<? extends TRef> that);
   }
 }

--- a/src/main/java/minijava/ast/Class.java
+++ b/src/main/java/minijava/ast/Class.java
@@ -21,11 +21,11 @@ public class Class<TRef> {
     this.methods = Collections.unmodifiableList(methods);
   }
 
-  public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+  public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
     return visitor.visitClassDeclaration(this);
   }
 
   public interface Visitor<TRef, TReturn> {
-    TReturn visitClassDeclaration(Class<TRef> that);
+    TReturn visitClassDeclaration(Class<? extends TRef> that);
   }
 }

--- a/src/main/java/minijava/ast/Expression.java
+++ b/src/main/java/minijava/ast/Expression.java
@@ -3,7 +3,7 @@ package minijava.ast;
 import java.util.List;
 
 public interface Expression<TRef> {
-  <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor);
+  <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor);
 
   class ArrayAccessExpression<TRef> implements Expression<TRef> {
 
@@ -16,7 +16,7 @@ public interface Expression<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitArrayAccess(this);
     }
   }
@@ -33,7 +33,7 @@ public interface Expression<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitBinaryOperator(this);
     }
   }
@@ -47,7 +47,7 @@ public interface Expression<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitBooleanLiteral(this);
     }
   }
@@ -63,7 +63,7 @@ public interface Expression<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitFieldAccess(this);
     }
   }
@@ -77,7 +77,7 @@ public interface Expression<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitIntegerLiteral(this);
     }
   }
@@ -96,7 +96,7 @@ public interface Expression<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitMethodCall(this);
     }
   }
@@ -112,7 +112,7 @@ public interface Expression<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitNewArrayExpr(this);
     }
   }
@@ -126,7 +126,7 @@ public interface Expression<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitNewObjectExpr(this);
     }
   }
@@ -142,7 +142,7 @@ public interface Expression<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitUnaryOperator(this);
     }
   }
@@ -157,7 +157,7 @@ public interface Expression<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitVariable(this);
     }
   }
@@ -198,24 +198,24 @@ public interface Expression<TRef> {
 
   interface Visitor<TRef, TReturn> {
 
-    TReturn visitBinaryOperator(BinaryOperatorExpression<TRef> that);
+    TReturn visitBinaryOperator(BinaryOperatorExpression<? extends TRef> that);
 
-    TReturn visitUnaryOperator(UnaryOperatorExpression<TRef> that);
+    TReturn visitUnaryOperator(UnaryOperatorExpression<? extends TRef> that);
 
-    TReturn visitMethodCall(MethodCallExpression<TRef> that);
+    TReturn visitMethodCall(MethodCallExpression<? extends TRef> that);
 
-    TReturn visitFieldAccess(FieldAccessExpression<TRef> that);
+    TReturn visitFieldAccess(FieldAccessExpression<? extends TRef> that);
 
-    TReturn visitArrayAccess(ArrayAccessExpression<TRef> that);
+    TReturn visitArrayAccess(ArrayAccessExpression<? extends TRef> that);
 
-    TReturn visitNewObjectExpr(NewObjectExpression<TRef> that);
+    TReturn visitNewObjectExpr(NewObjectExpression<? extends TRef> that);
 
-    TReturn visitNewArrayExpr(NewArrayExpression<TRef> size);
+    TReturn visitNewArrayExpr(NewArrayExpression<? extends TRef> size);
 
-    TReturn visitVariable(VariableExpression<TRef> that);
+    TReturn visitVariable(VariableExpression<? extends TRef> that);
 
-    TReturn visitBooleanLiteral(BooleanLiteralExpression<TRef> that);
+    TReturn visitBooleanLiteral(BooleanLiteralExpression<? extends TRef> that);
 
-    TReturn visitIntegerLiteral(IntegerLiteralExpression<TRef> that);
+    TReturn visitIntegerLiteral(IntegerLiteralExpression<? extends TRef> that);
   }
 }

--- a/src/main/java/minijava/ast/Field.java
+++ b/src/main/java/minijava/ast/Field.java
@@ -9,11 +9,11 @@ public class Field<TRef> {
     this.name = name;
   }
 
-  public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+  public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
     return visitor.visitField(this);
   }
 
   public interface Visitor<TRef, TRet> {
-    TRet visitField(Field<TRef> that);
+    TRet visitField(Field<? extends TRef> that);
   }
 }

--- a/src/main/java/minijava/ast/Method.java
+++ b/src/main/java/minijava/ast/Method.java
@@ -28,12 +28,12 @@ public class Method<TRef> {
     this.body = body;
   }
 
-  public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+  public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
     return visitor.visitMethod(this);
   }
 
   public interface Visitor<TRef, TRet> {
-    TRet visitMethod(Method<TRef> that);
+    TRet visitMethod(Method<? extends TRef> that);
   }
 
   public static class Parameter<TRef> {

--- a/src/main/java/minijava/ast/Program.java
+++ b/src/main/java/minijava/ast/Program.java
@@ -9,12 +9,12 @@ public class Program<TRef> {
     this.declarations = declarations;
   }
 
-  public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+  public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
     return visitor.visitProgram(this);
   }
 
   public interface Visitor<TRef, TReturn> {
 
-    TReturn visitProgram(Program<TRef> that);
+    TReturn visitProgram(Program<? extends TRef> that);
   }
 }

--- a/src/main/java/minijava/ast/Statement.java
+++ b/src/main/java/minijava/ast/Statement.java
@@ -4,15 +4,15 @@ import java.util.Optional;
 
 public interface Statement<TRef> extends BlockStatement<TRef> {
 
-  <TRet> TRet acceptVisitor(Statement.Visitor<TRef, TRet> visitor);
+  <TRet> TRet acceptVisitor(Statement.Visitor<? super TRef, TRet> visitor);
 
-  default <TRet> TRet acceptVisitor(BlockStatement.Visitor<TRef, TRet> visitor) {
-    return acceptVisitor((Statement.Visitor<TRef, TRet>) visitor);
+  default <TRet> TRet acceptVisitor(BlockStatement.Visitor<? super TRef, TRet> visitor) {
+    return acceptVisitor((Statement.Visitor<? super TRef, TRet>) visitor);
   }
 
   class EmptyStatement<TRef> implements Statement<TRef> {
     @Override
-    public <TRet> TRet acceptVisitor(Statement.Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Statement.Visitor<? super TRef, TRet> visitor) {
       return visitor.visitEmptyStatement(this);
     }
   }
@@ -29,7 +29,7 @@ public interface Statement<TRef> extends BlockStatement<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Statement.Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Statement.Visitor<? super TRef, TRet> visitor) {
       return visitor.visitIf(this);
     }
   }
@@ -46,7 +46,7 @@ public interface Statement<TRef> extends BlockStatement<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Statement.Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Statement.Visitor<? super TRef, TRet> visitor) {
       return visitor.visitReturn(this);
     }
   }
@@ -61,7 +61,7 @@ public interface Statement<TRef> extends BlockStatement<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Statement.Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Statement.Visitor<? super TRef, TRet> visitor) {
       return visitor.visitWhile(this);
     }
   }
@@ -75,23 +75,23 @@ public interface Statement<TRef> extends BlockStatement<TRef> {
     }
 
     @Override
-    public <TRet> TRet acceptVisitor(Statement.Visitor<TRef, TRet> visitor) {
+    public <TRet> TRet acceptVisitor(Statement.Visitor<? super TRef, TRet> visitor) {
       return visitor.visitExpressionStatement(this);
     }
   }
 
   interface Visitor<TRef, TRet> {
 
-    TRet visitBlock(Block<TRef> that);
+    TRet visitBlock(Block<? extends TRef> that);
 
-    TRet visitEmptyStatement(EmptyStatement<TRef> that);
+    TRet visitEmptyStatement(EmptyStatement<? extends TRef> that);
 
-    TRet visitIf(If<TRef> that);
+    TRet visitIf(If<? extends TRef> that);
 
-    TRet visitExpressionStatement(ExpressionStatement<TRef> that);
+    TRet visitExpressionStatement(ExpressionStatement<? extends TRef> that);
 
-    TRet visitWhile(While<TRef> that);
+    TRet visitWhile(While<? extends TRef> that);
 
-    TRet visitReturn(Return<TRef> that);
+    TRet visitReturn(Return<? extends TRef> that);
   }
 }

--- a/src/main/java/minijava/ast/Type.java
+++ b/src/main/java/minijava/ast/Type.java
@@ -10,11 +10,11 @@ public class Type<TRef> {
     this.dimension = dimension;
   }
 
-  public <TRet> TRet acceptVisitor(Visitor<TRef, TRet> visitor) {
+  public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
     return visitor.visitType(this);
   }
 
   public interface Visitor<TRef, TReturn> {
-    TReturn visitType(Type<TRef> that);
+    TReturn visitType(Type<? extends TRef> that);
   }
 }

--- a/src/main/java/minijava/util/PrettyPrinter.java
+++ b/src/main/java/minijava/util/PrettyPrinter.java
@@ -14,14 +14,14 @@ import minijava.ast.Class;
  * cheap to create new instances of this class and therefore it is generally not advisable to reuse
  * instances.
  */
-public class PrettyPrinter<TRef>
-    implements Program.Visitor<TRef, CharSequence>,
-        Class.Visitor<TRef, CharSequence>,
-        Field.Visitor<TRef, CharSequence>,
-        Method.Visitor<TRef, CharSequence>,
-        Type.Visitor<TRef, CharSequence>,
-        BlockStatement.Visitor<TRef, CharSequence>,
-        Expression.Visitor<TRef, CharSequence> {
+public class PrettyPrinter
+    implements Program.Visitor<Object, CharSequence>,
+        Class.Visitor<Object, CharSequence>,
+        Field.Visitor<Object, CharSequence>,
+        Method.Visitor<Object, CharSequence>,
+        Type.Visitor<Object, CharSequence>,
+        BlockStatement.Visitor<Object, CharSequence>,
+        Expression.Visitor<Object, CharSequence> {
 
   private int indentLevel = 0;
 
@@ -39,7 +39,7 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitProgram(Program<TRef> that) {
+  public CharSequence visitProgram(Program<? extends Object> that) {
     return that.declarations
         .stream()
         .sorted((left, right) -> left.name.compareTo(right.name))
@@ -48,7 +48,7 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitClassDeclaration(Class<TRef> that) {
+  public CharSequence visitClassDeclaration(Class<? extends Object> that) {
     StringBuilder sb = new StringBuilder("class ").append(that.name).append(" {");
     if (that.fields.isEmpty() && that.methods.isEmpty()) {
       return sb.append(" }").append(System.lineSeparator());
@@ -70,14 +70,14 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitMethod(Method<TRef> that) {
+  public CharSequence visitMethod(Method<? extends Object> that) {
     StringBuilder sb = new StringBuilder("public ");
     if (that.isStatic) {
       sb.append("static ");
     }
     sb.append(that.returnType.acceptVisitor(this)).append(" ").append(that.name).append("(");
-    Iterator<Method.Parameter<TRef>> iterator = that.parameters.iterator();
-    Method.Parameter<TRef> next;
+    Iterator<? extends Method.Parameter<?>> iterator = that.parameters.iterator();
+    Method.Parameter<? extends Object> next;
     if (iterator.hasNext()) {
       next = iterator.next();
       sb.append(next.type.acceptVisitor(this)).append(" ").append(next.name);
@@ -90,9 +90,9 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitBlock(Block<TRef> that) {
+  public CharSequence visitBlock(Block<? extends Object> that) {
     StringBuilder sb = new StringBuilder("{");
-    List<BlockStatement<TRef>> nonEmptyStatements =
+    List<BlockStatement<? extends Object>> nonEmptyStatements =
         that.statements
             .stream()
             .filter(s -> !(s instanceof Statement.EmptyStatement))
@@ -111,7 +111,7 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitIf(Statement.If<TRef> that) {
+  public CharSequence visitIf(Statement.If<? extends Object> that) {
     StringBuilder b = new StringBuilder().append("if (");
     // bracketing exception for condition in if statement applies here
     CharSequence condition = that.condition.acceptVisitor(this);
@@ -130,7 +130,7 @@ public class PrettyPrinter<TRef>
     if (!that.else_.isPresent()) {
       return b;
     }
-    Statement<TRef> else_ = that.else_.get();
+    Statement<? extends Object> else_ = that.else_.get();
     // if 'then' part was a block, 'else' follows '}' directly
     if (that.then instanceof Block) {
       b.append(" else");
@@ -151,7 +151,7 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitWhile(Statement.While<TRef> that) {
+  public CharSequence visitWhile(Statement.While<? extends Object> that) {
     StringBuilder sb = new StringBuilder("while (");
     // bracketing exception for condition in while statement applies here
     CharSequence condition = that.condition.acceptVisitor(this);
@@ -166,7 +166,7 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitField(Field<TRef> that) {
+  public CharSequence visitField(Field<? extends Object> that) {
     return new StringBuilder("public ")
         .append(that.type.acceptVisitor(this))
         .append(" ")
@@ -175,25 +175,26 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitType(Type<TRef> that) {
+  public CharSequence visitType(Type<? extends Object> that) {
     StringBuilder b = new StringBuilder(that.typeRef.toString());
     b.append(Strings.repeat("[]", that.dimension));
     return b;
   }
 
   @Override
-  public CharSequence visitExpressionStatement(Statement.ExpressionStatement<TRef> that) {
+  public CharSequence visitExpressionStatement(
+      Statement.ExpressionStatement<? extends Object> that) {
     CharSequence expr = that.expression.acceptVisitor(this);
     return new StringBuilder(outerParanthesesRemoved(expr)).append(";");
   }
 
   @Override
-  public CharSequence visitEmptyStatement(Statement.EmptyStatement<TRef> that) {
+  public CharSequence visitEmptyStatement(Statement.EmptyStatement<? extends Object> that) {
     return ";";
   }
 
   @Override
-  public CharSequence visitReturn(Statement.Return<TRef> that) {
+  public CharSequence visitReturn(Statement.Return<? extends Object> that) {
     StringBuilder b = new StringBuilder("return");
     if (that.expression.isPresent()) {
       b.append(" ");
@@ -204,7 +205,7 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitVariable(BlockStatement.Variable<TRef> that) {
+  public CharSequence visitVariable(BlockStatement.Variable<? extends Object> that) {
     StringBuilder b = new StringBuilder(that.type.acceptVisitor(this));
     b.append(" ");
     b.append(that.name);
@@ -216,7 +217,8 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitBinaryOperator(Expression.BinaryOperatorExpression<TRef> that) {
+  public CharSequence visitBinaryOperator(
+      Expression.BinaryOperatorExpression<? extends Object> that) {
     StringBuilder b = new StringBuilder("(");
     CharSequence left = that.left.acceptVisitor(this);
     b.append(left);
@@ -230,7 +232,8 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitUnaryOperator(Expression.UnaryOperatorExpression<TRef> that) {
+  public CharSequence visitUnaryOperator(
+      Expression.UnaryOperatorExpression<? extends Object> that) {
     StringBuilder b = new StringBuilder("(");
     b.append(that.op.string);
     b.append(that.expression.acceptVisitor(this));
@@ -239,15 +242,15 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitMethodCall(Expression.MethodCallExpression<TRef> that) {
+  public CharSequence visitMethodCall(Expression.MethodCallExpression<? extends Object> that) {
     StringBuilder b = new StringBuilder();
     b.append("(");
     b.append(that.self.acceptVisitor(this));
     b.append(".");
     b.append(that.method.toString());
     b.append("(");
-    Iterator<Expression<TRef>> iterator = that.arguments.iterator();
-    Expression<TRef> next;
+    Iterator<? extends Expression<?>> iterator = that.arguments.iterator();
+    Expression<? extends Object> next;
     if (iterator.hasNext()) {
       next = iterator.next();
       b.append(outerParanthesesRemoved(next.acceptVisitor(this)));
@@ -262,7 +265,7 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitFieldAccess(Expression.FieldAccessExpression<TRef> that) {
+  public CharSequence visitFieldAccess(Expression.FieldAccessExpression<? extends Object> that) {
     StringBuilder b = new StringBuilder("(");
     b.append(that.self.acceptVisitor(this));
     b.append(".");
@@ -272,7 +275,7 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitArrayAccess(Expression.ArrayAccessExpression<TRef> that) {
+  public CharSequence visitArrayAccess(Expression.ArrayAccessExpression<? extends Object> that) {
     StringBuilder b = new StringBuilder("(").append(that.array.acceptVisitor(this)).append("[");
     CharSequence indexExpr = that.index.acceptVisitor(this);
     b.append(outerParanthesesRemoved(indexExpr));
@@ -281,7 +284,7 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitNewObjectExpr(Expression.NewObjectExpression<TRef> that) {
+  public CharSequence visitNewObjectExpr(Expression.NewObjectExpression<? extends Object> that) {
     StringBuilder b = new StringBuilder("(new ");
     b.append(that.type.toString());
     b.append("())");
@@ -289,7 +292,7 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitNewArrayExpr(Expression.NewArrayExpression<TRef> that) {
+  public CharSequence visitNewArrayExpr(Expression.NewArrayExpression<? extends Object> that) {
     StringBuilder b = new StringBuilder("(new ").append(that.type.typeRef.toString()).append("[");
     // bracketing exception for definition of array size applies here
     CharSequence sizeExpr = outerParanthesesRemoved(that.size.acceptVisitor(this));
@@ -300,17 +303,19 @@ public class PrettyPrinter<TRef>
   }
 
   @Override
-  public CharSequence visitVariable(Expression.VariableExpression<TRef> that) {
+  public CharSequence visitVariable(Expression.VariableExpression<? extends Object> that) {
     return that.var.toString();
   }
 
   @Override
-  public CharSequence visitBooleanLiteral(Expression.BooleanLiteralExpression<TRef> that) {
+  public CharSequence visitBooleanLiteral(
+      Expression.BooleanLiteralExpression<? extends Object> that) {
     return Boolean.toString(that.literal);
   }
 
   @Override
-  public CharSequence visitIntegerLiteral(Expression.IntegerLiteralExpression<TRef> that) {
+  public CharSequence visitIntegerLiteral(
+      Expression.IntegerLiteralExpression<? extends Object> that) {
     return that.literal;
   }
 }

--- a/src/test/java/minijava/util/PrettyPrinterProperties.java
+++ b/src/test/java/minijava/util/PrettyPrinterProperties.java
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith;
 @RunWith(JUnitQuickcheck.class)
 public class PrettyPrinterProperties {
 
-  private static final PrettyPrinter<String> PRETTY_PRINTER = new PrettyPrinter<>();
+  private static final PrettyPrinter PRETTY_PRINTER = new PrettyPrinter();
 
   @Property(trials = 800)
   public void shouldBeIdempotent(

--- a/src/test/java/minijava/util/PrettyPrinterTest.java
+++ b/src/test/java/minijava/util/PrettyPrinterTest.java
@@ -17,11 +17,11 @@ import org.junit.Test;
 
 public class PrettyPrinterTest {
 
-  private PrettyPrinter<Object> prettyPrinter;
+  private PrettyPrinter prettyPrinter;
 
   @Before
   public void setup() {
-    prettyPrinter = new PrettyPrinter<>();
+    prettyPrinter = new PrettyPrinter();
   }
 
   @Test


### PR DESCRIPTION
Useful for PrettyPrinter. It can handle all 'Node<X>' types, no matter
what 'X' actually is, but it doesn't need to be generic itself.