### PR TITLE
Add Ref for name analysis and add Nameable interface

### DIFF
--- a/src/main/java/minijava/Cli.java
+++ b/src/main/java/minijava/Cli.java
@@ -15,6 +15,7 @@ import java.io.PrintStream;
 import java.nio.file.*;
 import java.util.ArrayList;
 import java.util.List;
+import minijava.ast.Nameable;
 import minijava.ast.Program;
 import minijava.lexer.Lexer;
 import minijava.parser.Parser;
@@ -103,7 +104,7 @@ class Cli {
   }
 
   private void printAst(InputStream in) {
-    Program<String> ast = new Parser(new Lexer(in)).parse();
+    Program<Nameable> ast = new Parser(new Lexer(in)).parse();
     out.print(ast.acceptVisitor(new PrettyPrinter()));
   }
 

--- a/src/main/java/minijava/ast/BlockStatement.java
+++ b/src/main/java/minijava/ast/BlockStatement.java
@@ -20,9 +20,9 @@ public interface BlockStatement<TRef> extends SyntaxElement {
     }
   }
 
-  class Variable<TRef> extends Base<TRef> {
+  class Variable<TRef> extends Base<TRef> implements Definition {
     public final Type<TRef> type;
-    public final String name;
+    private final String name;
     public final Expression<TRef> rhs;
 
     public Variable(Type<TRef> type, String name, Expression<TRef> rhs, SourceRange range) {
@@ -35,6 +35,11 @@ public interface BlockStatement<TRef> extends SyntaxElement {
     @Override
     public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
       return visitor.visitVariable(this);
+    }
+
+    @Override
+    public String name() {
+      return this.name;
     }
   }
 

--- a/src/main/java/minijava/ast/Class.java
+++ b/src/main/java/minijava/ast/Class.java
@@ -5,8 +5,8 @@ import java.util.List;
 import minijava.util.SourceRange;
 import minijava.util.SyntaxElement;
 
-public class Class<TRef> extends SyntaxElement.DefaultImpl {
-  public final String name;
+public class Class<TRef> extends SyntaxElement.DefaultImpl implements Definition {
+  private final String name;
   public final List<Field<TRef>> fields;
   public final List<Method<TRef>> methods;
 
@@ -27,6 +27,11 @@ public class Class<TRef> extends SyntaxElement.DefaultImpl {
 
   public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
     return visitor.visitClassDeclaration(this);
+  }
+
+  @Override
+  public String name() {
+    return this.name;
   }
 
   public interface Visitor<TRef, TReturn> {

--- a/src/main/java/minijava/ast/Definition.java
+++ b/src/main/java/minijava/ast/Definition.java
@@ -1,0 +1,3 @@
+package minijava.ast;
+
+public interface Definition extends Nameable {}

--- a/src/main/java/minijava/ast/Field.java
+++ b/src/main/java/minijava/ast/Field.java
@@ -3,14 +3,19 @@ package minijava.ast;
 import minijava.util.SourceRange;
 import minijava.util.SyntaxElement;
 
-public class Field<TRef> extends SyntaxElement.DefaultImpl {
+public class Field<TRef> extends SyntaxElement.DefaultImpl implements Definition {
   public final Type<TRef> type;
-  public final String name;
+  private final String name;
 
   public Field(Type<TRef> type, String name, SourceRange range) {
     super(range);
     this.type = type;
     this.name = name;
+  }
+
+  @Override
+  public String name() {
+    return this.name;
   }
 
   public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {

--- a/src/main/java/minijava/ast/Method.java
+++ b/src/main/java/minijava/ast/Method.java
@@ -4,10 +4,10 @@ import java.util.List;
 import minijava.util.SourceRange;
 import minijava.util.SyntaxElement;
 
-public class Method<TRef> extends SyntaxElement.DefaultImpl {
+public class Method<TRef> extends SyntaxElement.DefaultImpl implements Definition {
   public final boolean isStatic;
   public final Type<TRef> returnType;
-  public final String name;
+  private final String name;
   public final List<Parameter<TRef>> parameters;
   public final Block<TRef> body;
 
@@ -32,6 +32,11 @@ public class Method<TRef> extends SyntaxElement.DefaultImpl {
     this.body = body;
   }
 
+  @Override
+  public String name() {
+    return this.name;
+  }
+
   public <TRet> TRet acceptVisitor(Visitor<? super TRef, TRet> visitor) {
     return visitor.visitMethod(this);
   }
@@ -40,7 +45,7 @@ public class Method<TRef> extends SyntaxElement.DefaultImpl {
     TRet visitMethod(Method<? extends TRef> that);
   }
 
-  public static class Parameter<TRef> extends SyntaxElement.DefaultImpl {
+  public static class Parameter<TRef> extends SyntaxElement.DefaultImpl implements Definition {
     public final Type<TRef> type;
     public final String name;
 
@@ -48,6 +53,11 @@ public class Method<TRef> extends SyntaxElement.DefaultImpl {
       super(range);
       this.type = type;
       this.name = name;
+    }
+
+    @Override
+    public String name() {
+      return name;
     }
   }
 }

--- a/src/main/java/minijava/ast/Name.java
+++ b/src/main/java/minijava/ast/Name.java
@@ -1,0 +1,15 @@
+package minijava.ast;
+
+public class Name implements Nameable {
+
+  private final String name;
+
+  public Name(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+}

--- a/src/main/java/minijava/ast/Nameable.java
+++ b/src/main/java/minijava/ast/Nameable.java
@@ -1,0 +1,5 @@
+package minijava.ast;
+
+public interface Nameable {
+  String name();
+}

--- a/src/main/java/minijava/ast/Ref.java
+++ b/src/main/java/minijava/ast/Ref.java
@@ -1,0 +1,15 @@
+package minijava.ast;
+
+public class Ref implements Nameable {
+
+  private final Definition def;
+
+  public Ref(Definition def) {
+    this.def = def;
+  }
+
+  @Override
+  public String name() {
+    return def.name();
+  }
+}

--- a/src/main/java/minijava/parser/Parser.java
+++ b/src/main/java/minijava/parser/Parser.java
@@ -17,8 +17,8 @@ import minijava.util.SourceRange;
 
 public class Parser {
   private static final Token EOF_TOKEN = new Token(EOF, SourceRange.FIRST_CHAR, null);
-  private static final Expression<String> THIS_EXPR =
-      new Expression.Variable<>("this", SourceRange.FIRST_CHAR);
+  private static final Expression<Nameable> THIS_EXPR =
+      new Expression.Variable<>(new Name("this"), SourceRange.FIRST_CHAR);
   private final LookAheadIterator<Token> tokens;
   private Token currentToken;
 
@@ -89,15 +89,15 @@ public class Parser {
     return true;
   }
 
-  public Program<String> parse() {
+  public Program<Nameable> parse() {
     consumeToken();
     return parseProgramm();
   }
 
   /** Program -> ClassDeclaration* */
-  private Program<String> parseProgramm() {
+  private Program<Nameable> parseProgramm() {
     SourcePosition begin = SourcePosition.BEGIN_OF_PROGRAM;
-    List<Class<String>> classes = new ArrayList<>();
+    List<Class<Nameable>> classes = new ArrayList<>();
     while (isCurrentTokenNotTypeOf(EOF)) {
       classes.add(parseClassDeclaration());
     }
@@ -106,12 +106,12 @@ public class Parser {
   }
 
   /** ClassDeclaration -> class IDENT { PublicClassMember* } */
-  private Class<String> parseClassDeclaration() {
+  private Class<Nameable> parseClassDeclaration() {
     SourcePosition begin = expectAndConsume(CLASS).range.begin;
     Token identifier = expectAndConsume(IDENT);
     expectAndConsume(LBRACE);
-    List<Field<String>> fields = new ArrayList<>();
-    List<Method<String>> methods = new ArrayList<>();
+    List<Field<Nameable>> fields = new ArrayList<>();
+    List<Method<Nameable>> methods = new ArrayList<>();
     while (isCurrentTokenNotTypeOf(RBRACE) && isCurrentTokenNotTypeOf(EOF)) {
       parsePublicClassMember(fields, methods);
     }
@@ -120,14 +120,15 @@ public class Parser {
   }
 
   /** PublicClassMember -> public ClassMember */
-  private void parsePublicClassMember(List<Field<String>> fields, List<Method<String>> methods) {
+  private void parsePublicClassMember(
+      List<Field<Nameable>> fields, List<Method<Nameable>> methods) {
     SourcePosition begin = expectAndConsume(PUBLIC).range.begin;
     parseClassMember(fields, methods, begin);
   }
 
   /** ClassMember -> MainMethod | FieldOrMethod */
   private void parseClassMember(
-      List<Field<String>> fields, List<Method<String>> methods, SourcePosition begin) {
+      List<Field<Nameable>> fields, List<Method<Nameable>> methods, SourcePosition begin) {
     switch (currentToken.terminal) {
       case STATIC:
         methods.add(parseMainMethod(begin));
@@ -139,20 +140,21 @@ public class Parser {
   }
 
   /** MainMethod -> static void IDENT ( String [] IDENT ) Block */
-  private Method<String> parseMainMethod(SourcePosition begin) {
+  private Method<Nameable> parseMainMethod(SourcePosition begin) {
     expectAndConsume(STATIC);
     Token void_ = expectAndConsume(VOID);
-    Type<String> voidType = new Type<>("void", 0, void_.range);
+    Type<Nameable> voidType = new Type<>(new Name("void"), 0, void_.range);
     Token name = expectAndConsume(IDENT);
     expectAndConsume(LPAREN);
     SourcePosition typeBegin = expectAndConsume(IDENT, "String").range.begin;
     expectAndConsume(LBRACK);
     SourcePosition typeEnd = expectAndConsume(RBRACK).range.end;
-    Type<String> parameterType = new Type<>("String", 1, new SourceRange(typeBegin, typeEnd));
+    Type<Nameable> parameterType =
+        new Type<>(new Name("String"), 1, new SourceRange(typeBegin, typeEnd));
     Token ident = expectAndConsume(IDENT);
     expectAndConsume(RPAREN);
-    Block<String> block = parseBlock();
-    Method.Parameter<String> parameter =
+    Block<Nameable> block = parseBlock();
+    Method.Parameter<Nameable> parameter =
         new Method.Parameter<>(
             parameterType, ident.lexval, new SourceRange(typeBegin, ident.range.end));
     return new Method<>(
@@ -166,18 +168,18 @@ public class Parser {
 
   /** TypeIdentFieldOrMethod -> Type IDENT FieldOrMethod */
   private void parseTypeIdentFieldOrMethod(
-      List<Field<String>> fields, List<Method<String>> methods, SourcePosition begin) {
-    Type<String> type = parseType();
+      List<Field<Nameable>> fields, List<Method<Nameable>> methods, SourcePosition begin) {
+    Type<Nameable> type = parseType();
     String name = expectAndConsume(IDENT).lexval;
     parseFieldOrMethod(type, name, fields, methods, begin);
   }
 
   /** FieldOrMethod -> ; | Method */
   private void parseFieldOrMethod(
-      Type<String> type,
+      Type<Nameable> type,
       String name,
-      List<Field<String>> fields,
-      List<Method<String>> methods,
+      List<Field<Nameable>> fields,
+      List<Method<Nameable>> methods,
       SourcePosition begin) {
     if (isCurrentTokenTypeOf(SEMICOLON)) {
       SourcePosition end = expectAndConsume(SEMICOLON).range.end;
@@ -188,21 +190,21 @@ public class Parser {
   }
 
   /** Method -> ( Parameters? ) Block */
-  private Method<String> parseMethod(Type<String> type, String name, SourcePosition begin) {
-    List<Method.Parameter<String>> parameters = new ArrayList<>();
+  private Method<Nameable> parseMethod(Type<Nameable> type, String name, SourcePosition begin) {
+    List<Method.Parameter<Nameable>> parameters = new ArrayList<>();
     expectAndConsume(LPAREN);
     if (isCurrentTokenNotTypeOf(RPAREN)) {
       parameters = parseParameters();
     }
     expectAndConsume(RPAREN);
-    Block<String> block = parseBlock();
+    Block<Nameable> block = parseBlock();
     return new Method<>(
         false, type, name, parameters, block, new SourceRange(begin, block.range.end));
   }
 
   /** Parameters -> Parameter | Parameter , Parameters */
-  private List<Method.Parameter<String>> parseParameters() {
-    List<Method.Parameter<String>> parameters = new ArrayList<>();
+  private List<Method.Parameter<Nameable>> parseParameters() {
+    List<Method.Parameter<Nameable>> parameters = new ArrayList<>();
     parameters.add(parseParameter());
     while (isCurrentTokenTypeOf(COMMA)) {
       expectAndConsume(COMMA);
@@ -212,15 +214,15 @@ public class Parser {
   }
 
   /** Parameter -> Type IDENT */
-  private Method.Parameter<String> parseParameter() {
-    Type<String> type = parseType();
+  private Method.Parameter<Nameable> parseParameter() {
+    Type<Nameable> type = parseType();
     Token identifier = expectAndConsume(IDENT);
     return new Method.Parameter<>(
         type, identifier.lexval, new SourceRange(type.range.begin, identifier.range.end));
   }
 
   /** Type -> BasicType ([])* */
-  private Type<String> parseType() {
+  private Type<Nameable> parseType() {
     // Only later call is in parseLocalVariableDeclarationStatement()
     // parseType() does not recurse however, so we are safe.
     SourcePosition begin = currentToken.range.begin;
@@ -232,7 +234,7 @@ public class Parser {
       dimension++;
     }
     SourcePosition end = currentToken.range.end;
-    return new Type<>(type, dimension, new SourceRange(begin, end));
+    return new Type<>(new Name(type), dimension, new SourceRange(begin, end));
   }
 
   /** BasicType -> int | boolean | void | IDENT */
@@ -260,7 +262,7 @@ public class Parser {
    * Statement -> Block | EmptyStatement | IfStatement | ExpressionStatement | WhileStatement |
    * ReturnStatement
    */
-  private Statement<String> parseStatement() {
+  private Statement<Nameable> parseStatement() {
     // Also called from BlockStatement, IfStatement and WhileStatement.
     // There is possibility for endless recursion here, but that's OK
     // because it's not tail recursive (which we have to optimize away
@@ -285,8 +287,8 @@ public class Parser {
   }
 
   /** Block -> { BlockStatement* } */
-  private Block<String> parseBlock() {
-    List<BlockStatement<String>> blockStatements = new ArrayList<>();
+  private Block<Nameable> parseBlock() {
+    List<BlockStatement<Nameable>> blockStatements = new ArrayList<>();
     SourcePosition begin = expectAndConsume(LBRACE).range.begin;
     while (isCurrentTokenNotTypeOf(RBRACE) && isCurrentTokenNotTypeOf(EOF)) {
       blockStatements.add(parseBlockStatement());
@@ -296,7 +298,7 @@ public class Parser {
   }
 
   /** BlockStatement -> Statement | LocalVariableDeclarationStatement */
-  private BlockStatement<String> parseBlockStatement() {
+  private BlockStatement<Nameable> parseBlockStatement() {
     if (currentToken.isOneOf(INT, BOOLEAN, VOID)
         || matchCurrentAndLookAhead(IDENT, LBRACK, RBRACK)
         || matchCurrentAndLookAhead(IDENT, IDENT)) {
@@ -307,11 +309,11 @@ public class Parser {
   }
 
   /** LocalVariableDeclarationStatement -> Type IDENT (= Expression)? ; */
-  private BlockStatement<String> parseLocalVariableDeclarationStatement() {
-    Type<String> type = parseType();
+  private BlockStatement<Nameable> parseLocalVariableDeclarationStatement() {
+    Type<Nameable> type = parseType();
     SourcePosition begin = type.range.end;
     String identifier = expectAndConsume(IDENT).lexval;
-    Expression<String> expression = null;
+    Expression<Nameable> expression = null;
     if (isCurrentTokenTypeOf(ASSIGN)) {
       expectAndConsume(ASSIGN);
       expression = parseExpression();
@@ -321,30 +323,30 @@ public class Parser {
   }
 
   /** EmptyStatement -> ; */
-  private Statement<String> parseEmptyStatement() {
+  private Statement<Nameable> parseEmptyStatement() {
     SourceRange range = expectAndConsume(SEMICOLON).range;
     return new Statement.Empty<>(range);
   }
 
   /** WhileStatement -> while ( Expression ) Statement */
-  private Statement<String> parseWhileStatement() {
+  private Statement<Nameable> parseWhileStatement() {
     SourcePosition begin = expectAndConsume(WHILE).range.begin;
     expectAndConsume(LPAREN);
-    Expression<String> condition = parseExpression();
+    Expression<Nameable> condition = parseExpression();
     expectAndConsume(RPAREN);
-    Statement<String> body = parseStatement();
+    Statement<Nameable> body = parseStatement();
     return new Statement.While<>(condition, body, new SourceRange(begin, body.getRange().end));
   }
 
   /** IfStatement -> if ( Expression ) Statement (else Statement)? */
-  private Statement<String> parseIfStatement() {
+  private Statement<Nameable> parseIfStatement() {
     SourcePosition begin = expectAndConsume(IF).range.begin;
     expectAndConsume(LPAREN);
-    Expression<String> condition = parseExpression();
+    Expression<Nameable> condition = parseExpression();
     expectAndConsume(RPAREN);
-    Statement<String> then = parseStatement();
+    Statement<Nameable> then = parseStatement();
     SourcePosition end = then.getRange().end;
-    Statement<String> else_ = null;
+    Statement<Nameable> else_ = null;
     if (isCurrentTokenTypeOf(ELSE)) {
       expectAndConsume(ELSE);
       else_ = parseStatement();
@@ -354,17 +356,17 @@ public class Parser {
   }
 
   /** ExpressionStatement -> Expression ; */
-  private Statement<String> parseExpressionStatement() {
-    Expression<String> expression = parseExpression();
+  private Statement<Nameable> parseExpressionStatement() {
+    Expression<Nameable> expression = parseExpression();
     SourcePosition begin = expression.getRange().begin;
     SourcePosition end = expectAndConsume(SEMICOLON).range.end;
     return new Statement.ExpressionStatement<>(expression, new SourceRange(begin, end));
   }
 
   /** ReturnStatement -> return Expression? ; */
-  private Statement<String> parseReturnStatement() {
+  private Statement<Nameable> parseReturnStatement() {
     SourcePosition begin = expectAndConsume(RETURN).range.begin;
-    Expression<String> expression = null;
+    Expression<Nameable> expression = null;
     if (isCurrentTokenNotTypeOf(SEMICOLON)) {
       expression = parseExpression();
     }
@@ -373,14 +375,14 @@ public class Parser {
   }
 
   /** Expression is parsed with Precedence Climbing */
-  private Expression<String> parseExpression() {
+  private Expression<Nameable> parseExpression() {
     return parseExpressionWithPrecedenceClimbing(0);
   }
 
-  private Expression<String> parseExpressionWithPrecedenceClimbing(int minPrecedence) {
+  private Expression<Nameable> parseExpressionWithPrecedenceClimbing(int minPrecedence) {
     // This is the other method that could possibly blow up the stack,
     // which we can do nothing about.
-    Expression<String> result = parseUnaryExpression();
+    Expression<Nameable> result = parseUnaryExpression();
     while (isCurrentTokenBinaryOperator()
         && isOperatorPrecedenceGreaterOrEqualThan(minPrecedence)) {
       Expression.BinOp operator = getBinaryOperator(currentToken);
@@ -389,7 +391,7 @@ public class Parser {
         precedence++;
       }
       consumeToken();
-      Expression<String> rhs = parseExpressionWithPrecedenceClimbing(precedence);
+      Expression<Nameable> rhs = parseExpressionWithPrecedenceClimbing(precedence);
       SourcePosition begin = result.getRange().begin;
       SourcePosition end = rhs.getRange().end;
       result = new Expression.BinaryOperator<>(operator, result, rhs, new SourceRange(begin, end));
@@ -444,7 +446,7 @@ public class Parser {
   }
 
   /** UnaryExpression -> PostfixExpression | (! | -) UnaryExpression */
-  private Expression<String> parseUnaryExpression() {
+  private Expression<Nameable> parseUnaryExpression() {
     if (currentToken.isOneOf(NOT, SUB)) {
       Expression.UnOp operator = getUnaryOperator(currentToken);
       SourceRange range = consumeToken().range;
@@ -454,8 +456,8 @@ public class Parser {
   }
 
   /** PostfixExpression -> PrimaryExpression (PostfixOp)* */
-  private Expression<String> parsePostfixExpression() {
-    Expression<String> primaryExpression = parsePrimaryExpression();
+  private Expression<Nameable> parsePostfixExpression() {
+    Expression<Nameable> primaryExpression = parsePrimaryExpression();
     while ((isCurrentTokenTypeOf(LBRACK) || isCurrentTokenTypeOf(PERIOD))
         && isCurrentTokenNotTypeOf(EOF)) {
       primaryExpression = parsePostfixOp(primaryExpression);
@@ -464,7 +466,7 @@ public class Parser {
   }
 
   /** PostfixOp -> MethodInvocation | FieldAccess | ArrayAccess */
-  private Expression<String> parsePostfixOp(Expression<String> lhs) {
+  private Expression<Nameable> parsePostfixOp(Expression<Nameable> lhs) {
     switch (currentToken.terminal) {
       case PERIOD:
         return parseDotIdentFieldAccessMethodInvocation(lhs);
@@ -476,7 +478,7 @@ public class Parser {
   }
 
   /** DotIdentFieldAccessMethodInvocation -> . IDENT (MethodInvocation)? */
-  private Expression<String> parseDotIdentFieldAccessMethodInvocation(Expression<String> lhs) {
+  private Expression<Nameable> parseDotIdentFieldAccessMethodInvocation(Expression<Nameable> lhs) {
     expectAndConsume(PERIOD);
     Token identifier = expectAndConsume(IDENT);
     // is it FieldAccess (false) or MethodInvocation (true)?
@@ -484,29 +486,29 @@ public class Parser {
       return parseMethodInvocation(lhs, identifier.lexval);
     }
     SourceRange range = new SourceRange(lhs.getRange().begin, identifier.range.end);
-    return new Expression.FieldAccess<>(lhs, identifier.lexval, range);
+    return new Expression.FieldAccess<>(lhs, new Name(identifier.lexval), range);
   }
 
   /** MethodInvocation -> ( Arguments ) */
-  private Expression<String> parseMethodInvocation(Expression<String> lhs, String identifier) {
+  private Expression<Nameable> parseMethodInvocation(Expression<Nameable> lhs, String identifier) {
     expectAndConsume(LPAREN);
-    List<Expression<String>> arguments = parseArguments();
+    List<Expression<Nameable>> arguments = parseArguments();
     SourcePosition end = expectAndConsume(RPAREN).range.end;
     SourceRange range = new SourceRange(lhs.getRange().begin, end);
-    return new Expression.MethodCall<>(lhs, identifier, arguments, range);
+    return new Expression.MethodCall<>(lhs, new Name(identifier), arguments, range);
   }
 
   /** ArrayAccess -> [ Expression ] */
-  private Expression<String> parseArrayAccess(Expression<String> array) {
+  private Expression<Nameable> parseArrayAccess(Expression<Nameable> array) {
     expectAndConsume(LBRACK);
-    Expression<String> index = parseExpression();
+    Expression<Nameable> index = parseExpression();
     SourcePosition end = expectAndConsume(RBRACK).range.end;
     return new Expression.ArrayAccess<>(array, index, new SourceRange(array.getRange().begin, end));
   }
 
   /** Arguments -> (Expression (,Expression)*)? */
-  private List<Expression<String>> parseArguments() {
-    List<Expression<String>> arguments = new ArrayList<>();
+  private List<Expression<Nameable>> parseArguments() {
+    List<Expression<Nameable>> arguments = new ArrayList<>();
     if (isCurrentTokenNotTypeOf(RPAREN)) {
       arguments.add(parseExpression());
       while (isCurrentTokenTypeOf(COMMA) && isCurrentTokenNotTypeOf(EOF)) {
@@ -521,13 +523,13 @@ public class Parser {
    * PrimaryExpression -> null | false | true | INTEGER_LITERAL | IDENT | IDENT ( Arguments ) | this
    * | ( Expression ) | NewObjectArrayExpression
    */
-  private Expression<String> parsePrimaryExpression() {
-    Expression<String> primaryExpression = null;
+  private Expression<Nameable> parsePrimaryExpression() {
+    Expression<Nameable> primaryExpression = null;
     SourceRange range = null;
     switch (currentToken.terminal) {
       case NULL:
         range = expectAndConsume(NULL).range;
-        primaryExpression = new Expression.Variable<>("null", range);
+        primaryExpression = new Expression.Variable<>(new Name("null"), range);
         break;
       case FALSE:
         range = expectAndConsume(FALSE).range;
@@ -543,20 +545,21 @@ public class Parser {
         break;
       case IDENT:
         Token identifier = expectAndConsume(IDENT);
-        List<Expression<String>> arguments;
+        List<Expression<Nameable>> arguments;
         if (isCurrentTokenTypeOf(LPAREN)) {
           expectAndConsume(LPAREN);
           arguments = parseArguments();
           range = new SourceRange(identifier.range.begin, expectAndConsume(RPAREN).range.end);
           primaryExpression =
-              new Expression.MethodCall<>(THIS_EXPR, identifier.lexval, arguments, range);
+              new Expression.MethodCall<>(THIS_EXPR, new Name(identifier.lexval), arguments, range);
         } else {
-          primaryExpression = new Expression.Variable<>(identifier.lexval, identifier.range);
+          primaryExpression =
+              new Expression.Variable<>(new Name(identifier.lexval), identifier.range);
         }
         break;
       case THIS:
         range = expectAndConsume(THIS).range;
-        primaryExpression = new Expression.Variable<>("this", range);
+        primaryExpression = new Expression.Variable<>(new Name("this"), range);
         break;
       case LPAREN:
         expectAndConsume(LPAREN);
@@ -573,7 +576,7 @@ public class Parser {
   }
 
   /** NewObjectArrayExpression -> BasicType NewArrayExpression | IDENT NewObjectExpression */
-  private Expression<String> parseNewObjectArrayExpression() {
+  private Expression<Nameable> parseNewObjectArrayExpression() {
     SourcePosition begin = expectAndConsume(NEW).range.begin;
     switch (currentToken.terminal) {
       case INT:
@@ -601,17 +604,17 @@ public class Parser {
   }
 
   /** NewObjectExpression -> ( ) */
-  private Expression<String> parseNewObjectExpression(String type, SourcePosition begin) {
+  private Expression<Nameable> parseNewObjectExpression(String type, SourcePosition begin) {
     expectAndConsume(LPAREN);
     SourcePosition end = expectAndConsume(RPAREN).range.end;
-    return new Expression.NewObject<>(type, new SourceRange(begin, end));
+    return new Expression.NewObject<>(new Name(type), new SourceRange(begin, end));
   }
 
   /** NewArrayExpression -> [ Expression ] ([])* */
-  private Expression<String> parseNewArrayExpression(
+  private Expression<Nameable> parseNewArrayExpression(
       String elementTypeRef, SourcePosition newBegin, SourcePosition typeBegin) {
     expectAndConsume(LBRACK);
-    Expression<String> size = parseExpression();
+    Expression<Nameable> size = parseExpression();
     SourcePosition end = expectAndConsume(RBRACK).range.end;
     int dim = 1;
     while (matchCurrentAndLookAhead(LBRACK, RBRACK)) {
@@ -621,6 +624,7 @@ public class Parser {
     }
     SourceRange typeRange = new SourceRange(typeBegin, end);
     SourceRange newRange = new SourceRange(newBegin, end);
-    return new Expression.NewArray<>(new Type<>(elementTypeRef, dim, typeRange), size, newRange);
+    return new Expression.NewArray<>(
+        new Type<>(new Name(elementTypeRef), dim, typeRange), size, newRange);
   }
 }

--- a/src/main/java/minijava/util/PrettyPrinter.java
+++ b/src/main/java/minijava/util/PrettyPrinter.java
@@ -15,13 +15,13 @@ import minijava.ast.Class;
  * instances.
  */
 public class PrettyPrinter
-    implements Program.Visitor<Object, CharSequence>,
-        Class.Visitor<Object, CharSequence>,
-        Field.Visitor<Object, CharSequence>,
-        Method.Visitor<Object, CharSequence>,
-        Type.Visitor<Object, CharSequence>,
-        BlockStatement.Visitor<Object, CharSequence>,
-        Expression.Visitor<Object, CharSequence> {
+    implements Program.Visitor<Nameable, CharSequence>,
+        Class.Visitor<Nameable, CharSequence>,
+        Field.Visitor<Nameable, CharSequence>,
+        Method.Visitor<Nameable, CharSequence>,
+        Type.Visitor<Nameable, CharSequence>,
+        BlockStatement.Visitor<Nameable, CharSequence>,
+        Expression.Visitor<Nameable, CharSequence> {
 
   private int indentLevel = 0;
 
@@ -39,17 +39,17 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitProgram(Program<? extends Object> that) {
+  public CharSequence visitProgram(Program<? extends Nameable> that) {
     return that.declarations
         .stream()
-        .sorted((left, right) -> left.name.compareTo(right.name))
+        .sorted((left, right) -> left.name().compareTo(right.name()))
         .map(c -> c.acceptVisitor(this))
         .collect(Collectors.joining());
   }
 
   @Override
-  public CharSequence visitClassDeclaration(Class<? extends Object> that) {
-    StringBuilder sb = new StringBuilder("class ").append(that.name).append(" {");
+  public CharSequence visitClassDeclaration(Class<? extends Nameable> that) {
+    StringBuilder sb = new StringBuilder("class ").append(that.name()).append(" {");
     if (that.fields.isEmpty() && that.methods.isEmpty()) {
       return sb.append(" }").append(System.lineSeparator());
     }
@@ -57,12 +57,12 @@ public class PrettyPrinter
     indentLevel++;
     that.methods
         .stream()
-        .sorted((left, right) -> left.name.compareTo(right.name))
+        .sorted((left, right) -> left.name().compareTo(right.name()))
         .map(m -> m.acceptVisitor(this))
         .forEach(s -> sb.append(indent()).append(s).append(System.lineSeparator()));
     that.fields
         .stream()
-        .sorted((left, right) -> left.name.compareTo(right.name))
+        .sorted((left, right) -> left.name().compareTo(right.name()))
         .map(m -> m.acceptVisitor(this))
         .forEach(s -> sb.append(indent()).append(s).append(System.lineSeparator()));
     indentLevel--;
@@ -70,14 +70,14 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitMethod(Method<? extends Object> that) {
+  public CharSequence visitMethod(Method<? extends Nameable> that) {
     StringBuilder sb = new StringBuilder("public ");
     if (that.isStatic) {
       sb.append("static ");
     }
-    sb.append(that.returnType.acceptVisitor(this)).append(" ").append(that.name).append("(");
-    Iterator<? extends Method.Parameter<?>> iterator = that.parameters.iterator();
-    Method.Parameter<? extends Object> next;
+    sb.append(that.returnType.acceptVisitor(this)).append(" ").append(that.name()).append("(");
+    Iterator<? extends Method.Parameter<? extends Nameable>> iterator = that.parameters.iterator();
+    Method.Parameter<? extends Nameable> next;
     if (iterator.hasNext()) {
       next = iterator.next();
       sb.append(next.type.acceptVisitor(this)).append(" ").append(next.name);
@@ -90,9 +90,9 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitBlock(Block<? extends Object> that) {
+  public CharSequence visitBlock(Block<? extends Nameable> that) {
     StringBuilder sb = new StringBuilder("{");
-    List<BlockStatement<? extends Object>> nonEmptyStatements =
+    List<BlockStatement<? extends Nameable>> nonEmptyStatements =
         that.statements
             .stream()
             .filter(s -> !(s instanceof Statement.Empty))
@@ -111,7 +111,7 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitIf(Statement.If<? extends Object> that) {
+  public CharSequence visitIf(Statement.If<? extends Nameable> that) {
     StringBuilder b = new StringBuilder().append("if (");
     // bracketing exception for condition in if statement applies here
     CharSequence condition = that.condition.acceptVisitor(this);
@@ -130,7 +130,7 @@ public class PrettyPrinter
     if (!that.else_.isPresent()) {
       return b;
     }
-    Statement<? extends Object> else_ = that.else_.get();
+    Statement<? extends Nameable> else_ = that.else_.get();
     // if 'then' part was a block, 'else' follows '}' directly
     if (that.then instanceof Block) {
       b.append(" else");
@@ -151,7 +151,7 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitWhile(Statement.While<? extends Object> that) {
+  public CharSequence visitWhile(Statement.While<? extends Nameable> that) {
     StringBuilder sb = new StringBuilder("while (");
     // bracketing exception for condition in while statement applies here
     CharSequence condition = that.condition.acceptVisitor(this);
@@ -166,35 +166,35 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitField(Field<? extends Object> that) {
+  public CharSequence visitField(Field<? extends Nameable> that) {
     return new StringBuilder("public ")
         .append(that.type.acceptVisitor(this))
         .append(" ")
-        .append(that.name)
+        .append(that.name())
         .append(";");
   }
 
   @Override
-  public CharSequence visitType(Type<? extends Object> that) {
-    StringBuilder b = new StringBuilder(that.typeRef.toString());
+  public CharSequence visitType(Type<? extends Nameable> that) {
+    StringBuilder b = new StringBuilder(that.typeRef.name());
     b.append(Strings.repeat("[]", that.dimension));
     return b;
   }
 
   @Override
   public CharSequence visitExpressionStatement(
-      Statement.ExpressionStatement<? extends Object> that) {
+      Statement.ExpressionStatement<? extends Nameable> that) {
     CharSequence expr = that.expression.acceptVisitor(this);
     return new StringBuilder(outerParanthesesRemoved(expr)).append(";");
   }
 
   @Override
-  public CharSequence visitEmpty(Statement.Empty<? extends Object> that) {
+  public CharSequence visitEmpty(Statement.Empty<? extends Nameable> that) {
     return ";";
   }
 
   @Override
-  public CharSequence visitReturn(Statement.Return<? extends Object> that) {
+  public CharSequence visitReturn(Statement.Return<? extends Nameable> that) {
     StringBuilder b = new StringBuilder("return");
     if (that.expression.isPresent()) {
       b.append(" ");
@@ -205,10 +205,10 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitVariable(BlockStatement.Variable<? extends Object> that) {
+  public CharSequence visitVariable(BlockStatement.Variable<? extends Nameable> that) {
     StringBuilder b = new StringBuilder(that.type.acceptVisitor(this));
     b.append(" ");
-    b.append(that.name);
+    b.append(that.name());
     if (that.rhs != null) {
       b.append(" = ");
       b.append(outerParanthesesRemoved(that.rhs.acceptVisitor(this)));
@@ -217,7 +217,7 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitBinaryOperator(Expression.BinaryOperator<? extends Object> that) {
+  public CharSequence visitBinaryOperator(Expression.BinaryOperator<? extends Nameable> that) {
     StringBuilder b = new StringBuilder("(");
     CharSequence left = that.left.acceptVisitor(this);
     b.append(left);
@@ -231,7 +231,7 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitUnaryOperator(Expression.UnaryOperator<? extends Object> that) {
+  public CharSequence visitUnaryOperator(Expression.UnaryOperator<? extends Nameable> that) {
     StringBuilder b = new StringBuilder("(");
     b.append(that.op.string);
     b.append(that.expression.acceptVisitor(this));
@@ -240,15 +240,15 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitMethodCall(Expression.MethodCall<? extends Object> that) {
+  public CharSequence visitMethodCall(Expression.MethodCall<? extends Nameable> that) {
     StringBuilder b = new StringBuilder();
     b.append("(");
     b.append(that.self.acceptVisitor(this));
     b.append(".");
-    b.append(that.method.toString());
+    b.append(that.method.name());
     b.append("(");
-    Iterator<? extends Expression<?>> iterator = that.arguments.iterator();
-    Expression<? extends Object> next;
+    Iterator<? extends Expression<? extends Nameable>> iterator = that.arguments.iterator();
+    Expression<? extends Nameable> next;
     if (iterator.hasNext()) {
       next = iterator.next();
       b.append(outerParanthesesRemoved(next.acceptVisitor(this)));
@@ -263,17 +263,17 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitFieldAccess(Expression.FieldAccess<? extends Object> that) {
+  public CharSequence visitFieldAccess(Expression.FieldAccess<? extends Nameable> that) {
     StringBuilder b = new StringBuilder("(");
     b.append(that.self.acceptVisitor(this));
     b.append(".");
-    b.append(that.field.toString());
+    b.append(that.field.name());
     b.append(")");
     return b;
   }
 
   @Override
-  public CharSequence visitArrayAccess(Expression.ArrayAccess<? extends Object> that) {
+  public CharSequence visitArrayAccess(Expression.ArrayAccess<? extends Nameable> that) {
     StringBuilder b = new StringBuilder("(").append(that.array.acceptVisitor(this)).append("[");
     CharSequence indexExpr = that.index.acceptVisitor(this);
     b.append(outerParanthesesRemoved(indexExpr));
@@ -282,16 +282,16 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitNewObject(Expression.NewObject<? extends Object> that) {
+  public CharSequence visitNewObject(Expression.NewObject<? extends Nameable> that) {
     StringBuilder b = new StringBuilder("(new ");
-    b.append(that.type.toString());
+    b.append(that.type.name());
     b.append("())");
     return b;
   }
 
   @Override
-  public CharSequence visitNewArray(Expression.NewArray<? extends Object> that) {
-    StringBuilder b = new StringBuilder("(new ").append(that.type.typeRef.toString()).append("[");
+  public CharSequence visitNewArray(Expression.NewArray<? extends Nameable> that) {
+    StringBuilder b = new StringBuilder("(new ").append(that.type.typeRef.name()).append("[");
     // bracketing exception for definition of array size applies here
     CharSequence sizeExpr = outerParanthesesRemoved(that.size.acceptVisitor(this));
     return b.append(sizeExpr)
@@ -301,17 +301,17 @@ public class PrettyPrinter
   }
 
   @Override
-  public CharSequence visitVariable(Expression.Variable<? extends Object> that) {
-    return that.var.toString();
+  public CharSequence visitVariable(Expression.Variable<? extends Nameable> that) {
+    return that.var.name();
   }
 
   @Override
-  public CharSequence visitBooleanLiteral(Expression.BooleanLiteral<? extends Object> that) {
+  public CharSequence visitBooleanLiteral(Expression.BooleanLiteral<? extends Nameable> that) {
     return Boolean.toString(that.literal);
   }
 
   @Override
-  public CharSequence visitIntegerLiteral(Expression.IntegerLiteral<? extends Object> that) {
+  public CharSequence visitIntegerLiteral(Expression.IntegerLiteral<? extends Nameable> that) {
     return that.literal;
   }
 }

--- a/src/test/java/minijava/util/GeneratedProgram.java
+++ b/src/test/java/minijava/util/GeneratedProgram.java
@@ -1,11 +1,12 @@
 package minijava.util;
 
+import minijava.ast.Nameable;
 import minijava.ast.Program;
 
 class GeneratedProgram {
-  final Program<String> program;
+  final Program<Nameable> program;
 
-  GeneratedProgram(Program<String> program) {
+  GeneratedProgram(Program<Nameable> program) {
     this.program = program;
   }
 }

--- a/src/test/java/minijava/util/PrettyPrinterProperties.java
+++ b/src/test/java/minijava/util/PrettyPrinterProperties.java
@@ -6,6 +6,7 @@ import com.pholser.junit.quickcheck.generator.Size;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
 import java.util.Arrays;
 import java.util.List;
+import minijava.ast.Nameable;
 import minijava.ast.Program;
 import minijava.lexer.Lexer;
 import minijava.parser.Parser;
@@ -16,21 +17,19 @@ import org.junit.runner.RunWith;
 @RunWith(JUnitQuickcheck.class)
 public class PrettyPrinterProperties {
 
-  private static final PrettyPrinter PRETTY_PRINTER = new PrettyPrinter();
-
   @Property(trials = 800)
   public void shouldBeIdempotent(
       @From(ProgramGenerator.class) @Size(max = 1500) GeneratedProgram p) {
 
-    String expected = p.program.acceptVisitor(PRETTY_PRINTER).toString();
+    String expected = p.program.acceptVisitor(new PrettyPrinter()).toString();
 
     // Debug printfs:
     //    System.out.println("expected:");
     //    System.out.println(expected);
 
-    Program<String> parsed = new Parser(new Lexer(expected)).parse();
+    Program<Nameable> parsed = new Parser(new Lexer(expected)).parse();
 
-    String actual = parsed.acceptVisitor(PRETTY_PRINTER).toString();
+    String actual = parsed.acceptVisitor(new PrettyPrinter()).toString();
 
     // Debug printfs:
     //    System.out.println("actual:");

--- a/src/test/java/minijava/util/PrettyPrinterTest.java
+++ b/src/test/java/minijava/util/PrettyPrinterTest.java
@@ -11,6 +11,8 @@ import minijava.ast.Class;
 import minijava.ast.Expression.*;
 import minijava.ast.Method.Parameter;
 import minijava.ast.Statement.*;
+import minijava.lexer.Lexer;
+import minijava.parser.Parser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +28,7 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitProgramWithThreeEmptyClasses_SortedAlphabetically() throws Exception {
-    Program<Object> p =
+    Program<Nameable> p =
         new Program<>(
             ImmutableList.of(
                 new Class<>("A", ImmutableList.of(), ImmutableList.of(), r),
@@ -39,10 +41,10 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitClassWithOneField() throws Exception {
-    Class<Object> node =
+    Class<Nameable> node =
         new Class<>(
             "Foo",
-            ImmutableList.of(new Field<>(new Type<>("int", 0, r), "i", r)),
+            ImmutableList.of(new Field<>(new Type<>(new Name("int"), 0, r), "i", r)),
             ImmutableList.of(),
             r);
     CharSequence actual = node.acceptVisitor(prettyPrinter);
@@ -51,15 +53,15 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitClassWithMultipleFields_fieldsAreOrderedAlphabetically() throws Exception {
-    Class<Object> node =
+    Class<Nameable> node =
         new Class<>(
             "Foo",
             ImmutableList.of(
-                new Field<>(new Type<>("boolean", 0, r), "G", r),
-                new Field<>(new Type<>("int", 0, r), "U", r),
-                new Field<>(new Type<>("int", 0, r), "A", r),
-                new Field<>(new Type<>("int", 0, r), "Z", r),
-                new Field<>(new Type<>("boolean", 0, r), "B", r)),
+                new Field<>(new Type<>(new Name("boolean"), 0, r), "G", r),
+                new Field<>(new Type<>(new Name("int"), 0, r), "U", r),
+                new Field<>(new Type<>(new Name("int"), 0, r), "A", r),
+                new Field<>(new Type<>(new Name("int"), 0, r), "Z", r),
+                new Field<>(new Type<>(new Name("boolean"), 0, r), "B", r)),
             ImmutableList.of(),
             r);
     CharSequence actual = node.acceptVisitor(prettyPrinter);
@@ -79,14 +81,14 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitClassWithOneEmptyMethod() throws Exception {
-    Class<Object> node =
+    Class<Nameable> node =
         new Class<>(
             "Foo",
             ImmutableList.of(),
             ImmutableList.of(
                 new Method<>(
                     true,
-                    new Type<>("int", 0, r),
+                    new Type<>(new Name("int"), 0, r),
                     "m",
                     ImmutableList.of(),
                     new Block<>(ImmutableList.of(), r),
@@ -99,28 +101,28 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitClassWithMultipleMethods_methodsAreOrderedAlphabetically() throws Exception {
-    Class<Object> node =
+    Class<Nameable> node =
         new Class<>(
             "Foo",
             ImmutableList.of(),
             ImmutableList.of(
                 new Method<>(
                     false,
-                    new Type<>("int", 0, r),
+                    new Type<>(new Name("int"), 0, r),
                     "a",
                     ImmutableList.of(),
                     new Block<>(ImmutableList.of(), r),
                     r),
                 new Method<>(
                     false,
-                    new Type<>("int", 0, r),
+                    new Type<>(new Name("int"), 0, r),
                     "Z",
                     ImmutableList.of(),
                     new Block<>(ImmutableList.of(), r),
                     r),
                 new Method<>(
                     false,
-                    new Type<>("int", 0, r),
+                    new Type<>(new Name("int"), 0, r),
                     "B",
                     ImmutableList.of(),
                     new Block<>(ImmutableList.of(), r),
@@ -141,14 +143,14 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitMethodWithParametersAndBodyWithEmptyStatements() throws Exception {
-    Method<Object> node =
+    Method<Nameable> node =
         new Method<>(
             true,
-            new Type<>("void", 0, r),
+            new Type<>(new Name("void"), 0, r),
             "main",
             ImmutableList.of(
-                new Parameter<>(new Type<>("String", 1, r), "args", r),
-                new Parameter<>(new Type<>("int", 0, r), "numArgs", r)),
+                new Parameter<>(new Type<>(new Name("String"), 1, r), "args", r),
+                new Parameter<>(new Type<>(new Name("int"), 0, r), "numArgs", r)),
             new Block<>(
                 ImmutableList.of(new Empty<>(r), new Empty<>(r), new Empty<>(r), new Empty<>(r)),
                 r),
@@ -161,15 +163,15 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitMethodWithNonEmptyBody() throws Exception {
-    Method<Object> node =
+    Method<Nameable> node =
         new Method<>(
             false,
-            new Type<>("int", 0, r),
+            new Type<>(new Name("int"), 0, r),
             "m",
             ImmutableList.of(),
             new Block<>(
                 ImmutableList.of(
-                    new ExpressionStatement<>(new IntegerLiteral<Object>("0", r) {}, r),
+                    new ExpressionStatement<>(new IntegerLiteral<Nameable>("0", r) {}, r),
                     new Empty<>(r)),
                 r),
             r);
@@ -179,12 +181,12 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitBlockWithMultipleStatements() throws Exception {
-    Block<Object> node =
+    Block<Nameable> node =
         new Block<>(
             ImmutableList.of(
-                new BlockStatement.Variable<>(new Type<>("int", 0, r), "i", null, r),
-                new BlockStatement.Variable<>(new Type<>("String", 2, r), "s", null, r),
-                new BlockStatement.Variable<>(new Type<>("boolean", 0, r), "b", null, r)),
+                new BlockStatement.Variable<>(new Type<>(new Name("int"), 0, r), "i", null, r),
+                new BlockStatement.Variable<>(new Type<>(new Name("String"), 2, r), "s", null, r),
+                new BlockStatement.Variable<>(new Type<>(new Name("boolean"), 0, r), "b", null, r)),
             r);
     CharSequence actual = node.acceptVisitor(prettyPrinter);
     assertThat(
@@ -193,14 +195,14 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitIfWithSingleThenStatement() throws Exception {
-    If<Object> node = new If<>(new BooleanLiteral<>(true, r), new Empty<>(r), null, r);
+    If<Nameable> node = new If<>(new BooleanLiteral<>(true, r), new Empty<>(r), null, r);
     CharSequence actual = node.acceptVisitor(prettyPrinter);
     assertThat(actual.toString(), is(equalTo(format("if (true)%n\t;"))));
   }
 
   @Test
   public void visitIfWithMultipleThenStatements() throws Exception {
-    If<Object> node =
+    If<Nameable> node =
         new If<>(
             new BooleanLiteral<>(true, r),
             new Block<>(ImmutableList.of(new Empty<>(r), new Empty<>(r)), r),
@@ -212,17 +214,17 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitLocalVariableDeclaration_WithoutInit() throws Exception {
-    BlockStatement.Variable<Object> node =
-        new BlockStatement.Variable<>(new Type<>("int", 0, r), "i", null, r);
+    BlockStatement.Variable<Nameable> node =
+        new BlockStatement.Variable<>(new Type<>(new Name("int"), 0, r), "i", null, r);
     CharSequence actual = node.acceptVisitor(prettyPrinter);
     assertThat(actual.toString(), is(equalTo("int i;")));
   }
 
   @Test
   public void visitLocalVariableDeclaration_WithInit() throws Exception {
-    BlockStatement.Variable<Object> node =
+    BlockStatement.Variable<Nameable> node =
         new BlockStatement.Variable<>(
-            new Type<>("int", 0, r),
+            new Type<>(new Name("int"), 0, r),
             "i",
             new BinaryOperator<>(
                 BinOp.PLUS, new IntegerLiteral<>("4", r), new IntegerLiteral<>("6", r), r),
@@ -233,26 +235,30 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitMethodCall_NoParameters() throws Exception {
-    MethodCall<Object> node = new MethodCall<>(new Variable<>("o", r), "m", ImmutableList.of(), r);
+    MethodCall<Nameable> node =
+        new MethodCall<>(new Variable<>(new Name("o"), r), new Name("m"), ImmutableList.of(), r);
     CharSequence actual = node.acceptVisitor(prettyPrinter);
     assertThat(actual.toString(), is(equalTo("(o.m())")));
   }
 
   @Test
   public void visitMethodCall_OneParameter() throws Exception {
-    MethodCall<Object> node =
+    MethodCall<Nameable> node =
         new MethodCall<>(
-            new Variable<>("o", r), "m", ImmutableList.of(new BooleanLiteral<>(true, r)), r);
+            new Variable<>(new Name("o"), r),
+            new Name("m"),
+            ImmutableList.of(new BooleanLiteral<>(true, r)),
+            r);
     CharSequence actual = node.acceptVisitor(prettyPrinter);
     assertThat(actual.toString(), is(equalTo("(o.m(true))")));
   }
 
   @Test
   public void visitMethodCall_MultipleParameters() throws Exception {
-    MethodCall<Object> node =
+    MethodCall<Nameable> node =
         new MethodCall<>(
-            new Variable<>("o", r),
-            "m",
+            new Variable<>(new Name("o"), r),
+            new Name("m"),
             ImmutableList.of(
                 new BooleanLiteral<>(true, r),
                 new BinaryOperator<>(
@@ -264,24 +270,25 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitFieldAccess() throws Exception {
-    FieldAccess<Object> node = new FieldAccess<>(new Variable<>("myObject", r), "field", r);
+    FieldAccess<Nameable> node =
+        new FieldAccess<>(new Variable<>(new Name("myObject"), r), new Name("field"), r);
     CharSequence actual = node.acceptVisitor(prettyPrinter);
     assertThat(actual.toString(), is(equalTo("(myObject.field)")));
   }
 
   @Test
   public void visitArrayAccess() throws Exception {
-    ArrayAccess<Object> node =
-        new ArrayAccess<>(new Variable<>("array", r), new IntegerLiteral<>("5", r), r);
+    ArrayAccess<Nameable> node =
+        new ArrayAccess<>(new Variable<>(new Name("array"), r), new IntegerLiteral<>("5", r), r);
     CharSequence actual = node.acceptVisitor(prettyPrinter);
     assertThat(actual.toString(), is(equalTo("(array[5])")));
   }
 
   @Test
   public void visitArrayAccess_IndexIsCompositeExpression() throws Exception {
-    ArrayAccess<Object> node =
+    ArrayAccess<Nameable> node =
         new ArrayAccess<>(
-            new Variable<>("array", r),
+            new Variable<>(new Name("array"), r),
             new UnaryOperator<>(
                 UnOp.NEGATE,
                 new BinaryOperator<>(
@@ -297,15 +304,15 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitNewObjectExpression() throws Exception {
-    NewObject<Object> node = new NewObject<>("MyClass", r);
+    NewObject<Nameable> node = new NewObject<>(new Name("MyClass"), r);
     CharSequence actual = node.acceptVisitor(prettyPrinter);
     assertThat(actual.toString(), is(equalTo("(new MyClass())")));
   }
 
   @Test
   public void visitNewArrayExpression() throws Exception {
-    NewArray<Object> node =
-        new NewArray<>(new Type("boolean", 4, r), new IntegerLiteral("25", r), r);
+    NewArray<Nameable> node =
+        new NewArray<>(new Type<>(new Name("boolean"), 4, r), new IntegerLiteral<>("25", r), r);
 
     CharSequence actual = node.acceptVisitor(prettyPrinter);
     assertThat(actual.toString(), is(equalTo("(new boolean[25][][][])")));
@@ -313,14 +320,14 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitNewArrayExpression_SizeExpressionIsACompositeExpression() throws Exception {
-    NewArray<Object> node =
+    NewArray<Nameable> node =
         new NewArray<>(
-            new Type("boolean", 4, r),
-            new BinaryOperator(
+            new Type<>(new Name("boolean"), 4, r),
+            new BinaryOperator<>(
                 BinOp.PLUS,
-                new BinaryOperator(
-                    BinOp.MINUS, new IntegerLiteral("25", r), new IntegerLiteral("5", r), r),
-                new UnaryOperator(UnOp.NEGATE, new IntegerLiteral("19", r), r),
+                new BinaryOperator<>(
+                    BinOp.MINUS, new IntegerLiteral<>("25", r), new IntegerLiteral<>("5", r), r),
+                new UnaryOperator<>(UnOp.NEGATE, new IntegerLiteral<>("19", r), r),
                 r),
             r);
 
@@ -330,7 +337,7 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitWhile() throws Exception {
-    While<Object> node =
+    While<Nameable> node =
         new While<>(
             new BinaryOperator<>(
                 BinOp.PLUS, new IntegerLiteral<>("6", r), new IntegerLiteral<>("2", r), r),
@@ -344,14 +351,14 @@ public class PrettyPrinterTest {
 
   @Test
   public void visitWhile_null() throws Exception {
-    While<Object> node = new While<>(new Variable<>("null", r), new Empty<>(r), r);
+    While<Nameable> node = new While<>(new Variable<>(new Name("null"), r), new Empty<>(r), r);
     CharSequence actual = node.acceptVisitor(prettyPrinter);
     assertThat(actual.toString(), is(equalTo(format("while (null)%n\t;"))));
   }
 
   @Test
   public void visitWhile_EmptyBlock() throws Exception {
-    While<Object> node =
+    While<Nameable> node =
         new While<>(
             new BinaryOperator<>(
                 BinOp.PLUS, new IntegerLiteral<>("6", r), new IntegerLiteral<>("2", r), r),
@@ -364,164 +371,25 @@ public class PrettyPrinterTest {
 
   @Test
   public void sampleProgram() throws Exception {
-    Program<Object> program =
-        new Program<>(
-            ImmutableList.of(
-                new Class<>(
-                    "HelloWorld",
-                    ImmutableList.of(
-                        new Field<>(new Type<>("int", 0, r), "c", r),
-                        new Field<>(new Type<>("boolean", 1, r), "array", r)),
-                    ImmutableList.of(
-                        new Method<>(
-                            true,
-                            new Type<>("void", 0, r),
-                            "main",
-                            ImmutableList.of(
-                                new Parameter<>(new Type<>("String", 1, r), "args", r)),
-                            new Block<>(
-                                ImmutableList.of(
-                                    new ExpressionStatement<>(
-                                        new MethodCall<>(
-                                            new FieldAccess<>(
-                                                new Variable<>("System", r), "out", r),
-                                            "println",
-                                            ImmutableList.of(
-                                                new BinaryOperator<>(
-                                                    BinOp.PLUS,
-                                                    new IntegerLiteral("43110", r),
-                                                    new IntegerLiteral<>("0", r),
-                                                    r)),
-                                            r),
-                                        r),
-                                    new BlockStatement.Variable(
-                                        new Type<>("boolean", 0, r),
-                                        "b",
-                                        new BinaryOperator(
-                                            BinOp.AND,
-                                            new BooleanLiteral(true, r),
-                                            new UnaryOperator(
-                                                Expression.UnOp.NOT,
-                                                new BooleanLiteral(false, r),
-                                                r),
-                                            r),
-                                        r),
-                                    new If<>(
-                                        new BinaryOperator(
-                                            BinOp.EQ,
-                                            new BinaryOperator(
-                                                BinOp.PLUS,
-                                                new IntegerLiteral("23", r),
-                                                new IntegerLiteral("19", r),
-                                                r),
-                                            new BinaryOperator(
-                                                BinOp.MULTIPLY,
-                                                new BinaryOperator(
-                                                    BinOp.PLUS,
-                                                    new IntegerLiteral("42", r),
-                                                    new IntegerLiteral("0", r),
-                                                    r),
-                                                new IntegerLiteral("1", r),
-                                                r),
-                                            r),
-                                        new Statement.ExpressionStatement<>(
-                                            new BinaryOperator(
-                                                BinOp.ASSIGN,
-                                                new Variable<>("b", r),
-                                                new BinaryOperator(
-                                                    BinOp.LT,
-                                                    new IntegerLiteral("0", r),
-                                                    new IntegerLiteral("1", r),
-                                                    r),
-                                                r),
-                                            r),
-                                        // else part of first if
-                                        new If(
-                                            new UnaryOperator(
-                                                Expression.UnOp.NOT,
-                                                new ArrayAccess(
-                                                    new Variable("array", r),
-                                                    new BinaryOperator(
-                                                        BinOp.PLUS,
-                                                        new IntegerLiteral("2", r),
-                                                        new IntegerLiteral("2", r),
-                                                        r),
-                                                    r),
-                                                r),
-                                            new Block(
-                                                ImmutableList.of(
-                                                    new BlockStatement.Variable(
-                                                        new Type<Object>("int", 0, r),
-                                                        "x",
-                                                        new IntegerLiteral<>("0", r),
-                                                        r),
-                                                    new Statement.ExpressionStatement<>(
-                                                        new BinaryOperator<>(
-                                                            BinOp.ASSIGN,
-                                                            new Variable<>("x", r),
-                                                            new BinaryOperator<>(
-                                                                BinOp.PLUS,
-                                                                new Variable<>("x", r),
-                                                                new IntegerLiteral<>("1", r),
-                                                                r),
-                                                            r),
-                                                        r)),
-                                                r),
-                                            new Block(
-                                                ImmutableList.of(
-                                                    new Statement.ExpressionStatement<>(
-                                                        new MethodCall<>(
-                                                            new NewObject<>("HelloWorld", r),
-                                                            "bar",
-                                                            ImmutableList.of(
-                                                                new BinaryOperator<>(
-                                                                    BinOp.PLUS,
-                                                                    new IntegerLiteral<>("42", r),
-                                                                    new BinaryOperator<>(
-                                                                        BinOp.MULTIPLY,
-                                                                        new IntegerLiteral<>(
-                                                                            "0", r),
-                                                                        new IntegerLiteral<>(
-                                                                            "1", r),
-                                                                        r),
-                                                                    r),
-                                                                new UnaryOperator<>(
-                                                                    UnOp.NEGATE,
-                                                                    new IntegerLiteral<>("1", r),
-                                                                    r)),
-                                                            r),
-                                                        r)),
-                                                r),
-                                            r),
-                                        r)),
-                                r),
-                            r),
-                        new Method<>(
-                            false,
-                            new Type<>("int", 0, r),
-                            "bar",
-                            ImmutableList.of(
-                                new Parameter<>(new Type<>("int", 0, r), "a", r),
-                                new Parameter<>(new Type<>("int", 0, r), "b", r)),
-                            new Block<>(
-                                ImmutableList.of(
-                                    new Return<>(
-                                        new BinaryOperator<>(
-                                            BinOp.ASSIGN,
-                                            new Variable<>("c", r),
-                                            new BinaryOperator<>(
-                                                BinOp.PLUS,
-                                                new Variable<>("a", r),
-                                                new Variable<>("b", r),
-                                                r),
-                                            r),
-                                        r)),
-                                r),
-                            r)),
-                    r)),
-            r);
-
-    CharSequence actual = program.acceptVisitor(prettyPrinter);
+    String input =
+        "class HelloWorld\n"
+            + "{\n"
+            + "\tpublic int c;\n"
+            + "\tpublic boolean[] array;\n"
+            + "\tpublic static /* blabla */ void main(String[] args)\n"
+            + "\t{ System.out.println( (43110 + 0) );\n"
+            + "\tboolean b = true && (!false);\n"
+            + "\tif (23+19 == (42+0)*1)\n"
+            + "\t\tb = (0 < 1);\n"
+            + "\t\telse if (!array[2+2]) {\n"
+            + "\t\t\tint x = 0;;\n"
+            + "\t\t\tx = x+1;\n"
+            + "\t\t} else {\n"
+            + "\t\t\tnew HelloWorld().bar(42+0*1, -1);\n"
+            + "\t\t}\n"
+            + "\t}\n"
+            + "\tpublic int bar(int a, int b) { return c = (a+b); }\n"
+            + "}";
 
     String expected =
         "class HelloWorld {%n"
@@ -544,6 +412,8 @@ public class PrettyPrinterTest {
             + "\tpublic int c;%n"
             + "}%n";
 
+    Program<Nameable> program = new Parser(new Lexer(input)).parse();
+    CharSequence actual = program.acceptVisitor(prettyPrinter);
     assertThat(actual.toString(), is(equalTo(format(expected))));
   }
 }

--- a/src/test/java/minijava/util/ProgramGenerator.java
+++ b/src/test/java/minijava/util/ProgramGenerator.java
@@ -41,10 +41,10 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
   }
 
   // ClassDeclaration*
-  private Program<String> generateProgram(SourceOfRandomness random) {
+  private Program<Nameable> generateProgram(SourceOfRandomness random) {
     nodes = 0;
     int n = nextArity(random, 10);
-    List<Class<String>> decls = new ArrayList<>();
+    List<Class<Nameable>> decls = new ArrayList<>();
     for (int i = 0; i < n; ++i) {
       decls.add(genClassDeclaration(random));
     }
@@ -54,16 +54,16 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
   }
 
   // class IDENT { ClassMember* }
-  private Class<String> genClassDeclaration(SourceOfRandomness random) {
+  private Class<Nameable> genClassDeclaration(SourceOfRandomness random) {
     int numberOfClassMembers = nextArity(random, 10);
-    List<Method<String>> methods = new ArrayList<>();
-    List<Field<String>> fields = new ArrayList<>();
+    List<Method<Nameable>> methods = new ArrayList<>();
+    List<Field<Nameable>> fields = new ArrayList<>();
     for (int i = 0; i < numberOfClassMembers; ++i) {
       Object member = genClassMember(random);
       if (member instanceof Field) {
-        fields.add((Field<String>) member);
+        fields.add((Field<Nameable>) member);
       } else {
-        methods.add((Method<String>) member);
+        methods.add((Method<Nameable>) member);
       }
     }
     nodes++;
@@ -77,24 +77,24 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
   }
 
   // public Type IDENT ;
-  private Field<String> genField(SourceOfRandomness random) {
+  private Field<Nameable> genField(SourceOfRandomness random) {
     nodes++;
     return new Field<>(genType(random), genIdent(random), SourceRange.FIRST_CHAR);
   }
 
   // public Type IDENT ( Parameters? ) Block
-  private Method<String> genMethod(SourceOfRandomness random) {
+  private Method<Nameable> genMethod(SourceOfRandomness random) {
     boolean isStatic = random.nextBoolean();
-    Type<String> returnType =
-        isStatic ? new Type<>("void", 0, SourceRange.FIRST_CHAR) : genType(random);
+    Type<Nameable> returnType =
+        isStatic ? new Type<>(new Name("void"), 0, SourceRange.FIRST_CHAR) : genType(random);
 
     int n = nextArity(random, 2);
-    List<Method.Parameter<String>> parameters = new ArrayList<>(n);
+    List<Method.Parameter<Nameable>> parameters = new ArrayList<>(n);
 
     if (isStatic) {
       parameters.add(
           new Method.Parameter<>(
-              new Type<>("String", 1, SourceRange.FIRST_CHAR),
+              new Type<>(new Name("String"), 1, SourceRange.FIRST_CHAR),
               genIdent(random),
               SourceRange.FIRST_CHAR));
     } else {
@@ -103,7 +103,7 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
       }
     }
 
-    Block<String> body = genBlock(random);
+    Block<Nameable> body = genBlock(random);
 
     nodes++;
     return new Method<>(
@@ -111,7 +111,7 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
   }
 
   // Type IDENT
-  private Method.Parameter<String> genParameter(SourceOfRandomness random) {
+  private Method.Parameter<Nameable> genParameter(SourceOfRandomness random) {
     nodes++;
     return new Method.Parameter<>(genType(random), genIdent(random), SourceRange.FIRST_CHAR);
   }
@@ -121,11 +121,11 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
   }
 
   // Type [ ] | BasicType
-  private Type<String> genType(SourceOfRandomness random) {
+  private Type<Nameable> genType(SourceOfRandomness random) {
     int n = random.nextInt(0, 3);
     String typeName = random.choose(Arrays.asList("void", "int", "boolean", genIdent(random)));
     nodes++;
-    return new Type<>(typeName, n, SourceRange.FIRST_CHAR);
+    return new Type<>(new Name(typeName), n, SourceRange.FIRST_CHAR);
   }
 
   /*
@@ -136,7 +136,7 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
   | WhileStatement
   | ReturnStatement
   */
-  private Statement<String> genStatement(SourceOfRandomness random) {
+  private Statement<Nameable> genStatement(SourceOfRandomness random) {
     return selectWithRandomWeight(
         random,
         tuple(0.1, this::genEmptyStatement),
@@ -148,9 +148,9 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
   }
 
   // { BlockStatement * }
-  private Block<String> genBlock(SourceOfRandomness random) {
+  private Block<Nameable> genBlock(SourceOfRandomness random) {
     int n = nextArity(random, 3);
-    List<BlockStatement<String>> statements = new ArrayList<>(n);
+    List<BlockStatement<Nameable>> statements = new ArrayList<>(n);
     for (int i = 0; i < n; ++i) {
       statements.add(genBlockStatement(random));
     }
@@ -159,34 +159,34 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
   }
 
   // Statement | LocalVariableDeclarationStatement
-  private BlockStatement<String> genBlockStatement(SourceOfRandomness random) {
+  private BlockStatement<Nameable> genBlockStatement(SourceOfRandomness random) {
     nodes++;
     return selectWithRandomWeight(
         random, tuple(0.3, this::genLocalVariableStatement), tuple(0.7, this::genStatement));
   }
 
   // Type IDENT (= Expression)? ;
-  private BlockStatement<String> genLocalVariableStatement(SourceOfRandomness random) {
+  private BlockStatement<Nameable> genLocalVariableStatement(SourceOfRandomness random) {
     nodes++;
     return new Statement.Variable<>(
         genType(random), genIdent(random), genExpression(random), SourceRange.FIRST_CHAR);
   }
 
   // ;
-  private Statement<String> genEmptyStatement(SourceOfRandomness random) {
+  private Statement<Nameable> genEmptyStatement(SourceOfRandomness random) {
     nodes++;
     return new Statement.Empty<>(SourceRange.FIRST_CHAR);
   }
 
   // while ( Expression ) Statement
-  private Statement<String> genWhileStatement(SourceOfRandomness random) {
+  private Statement<Nameable> genWhileStatement(SourceOfRandomness random) {
     nodes++;
     return new Statement.While<>(
         genExpression(random), genStatement(random), SourceRange.FIRST_CHAR);
   }
 
   // if ( Expression ) Statement (else Statement)?
-  private Statement<String> genIfStatement(SourceOfRandomness random) {
+  private Statement<Nameable> genIfStatement(SourceOfRandomness random) {
     nodes++;
     return selectWithRandomWeight(
         random,
@@ -201,13 +201,13 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
   }
 
   // Expression ;
-  private Statement<String> genExpressionStatement(SourceOfRandomness random) {
+  private Statement<Nameable> genExpressionStatement(SourceOfRandomness random) {
     nodes++;
     return new Statement.ExpressionStatement<>(genExpression(random), SourceRange.FIRST_CHAR);
   }
 
   // return Expression? ;
-  private Statement<String> genReturnStatement(SourceOfRandomness random) {
+  private Statement<Nameable> genReturnStatement(SourceOfRandomness random) {
     nodes++;
     return selectWithRandomWeight(
         random,
@@ -216,15 +216,16 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
   }
 
   // AssignmentExpression
-  private Expression<String> genExpression(SourceOfRandomness random) {
+  private Expression<Nameable> genExpression(SourceOfRandomness random) {
     while (true) {
       try {
         nodes++;
         return selectWithRandomWeight(
             random,
-            tuple(0.8, r -> new Expression.Variable<>(genIdent(r), SourceRange.FIRST_CHAR)),
-            tuple(0.1, r -> new Expression.Variable<>("null", SourceRange.FIRST_CHAR)),
-            tuple(0.1, r -> new Expression.Variable<>("this", SourceRange.FIRST_CHAR)),
+            tuple(
+                0.8, r -> new Expression.Variable<>(new Name(genIdent(r)), SourceRange.FIRST_CHAR)),
+            tuple(0.1, r -> new Expression.Variable<>(new Name("null"), SourceRange.FIRST_CHAR)),
+            tuple(0.1, r -> new Expression.Variable<>(new Name("this"), SourceRange.FIRST_CHAR)),
             tuple(
                 1.0, r -> new Expression.BooleanLiteral<>(r.nextBoolean(), SourceRange.FIRST_CHAR)),
             tuple(1.0, r -> new Expression.IntegerLiteral<>(genInt(r), SourceRange.FIRST_CHAR)),
@@ -247,18 +248,23 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
                 0.1,
                 r ->
                     new Expression.MethodCall<>(
-                        genExpression(r), genIdent(r), genArguments(r), SourceRange.FIRST_CHAR)),
+                        genExpression(r),
+                        new Name(genIdent(r)),
+                        genArguments(r),
+                        SourceRange.FIRST_CHAR)),
             tuple(
                 0.1,
                 r ->
                     new Expression.FieldAccess<>(
-                        genExpression(r), genIdent(r), SourceRange.FIRST_CHAR)),
+                        genExpression(r), new Name(genIdent(r)), SourceRange.FIRST_CHAR)),
             tuple(
                 0.1,
                 r ->
                     new Expression.ArrayAccess<>(
                         genExpression(r), genExpression(r), SourceRange.FIRST_CHAR)),
-            tuple(0.1, r -> new Expression.NewObject<>(genIdent(r), SourceRange.FIRST_CHAR)),
+            tuple(
+                0.1,
+                r -> new Expression.NewObject<>(new Name(genIdent(r)), SourceRange.FIRST_CHAR)),
             tuple(
                 0.1,
                 r ->
@@ -280,8 +286,8 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
     }
   }
 
-  private Type<String> genArrayType(SourceOfRandomness random) {
-    Type<String> t = genType(random);
+  private Type<Nameable> genArrayType(SourceOfRandomness random) {
+    Type<Nameable> t = genType(random);
     return new Type<>(t.typeRef, Math.max(t.dimension, 1), SourceRange.FIRST_CHAR);
   }
 
@@ -290,9 +296,9 @@ public class ProgramGenerator extends Generator<GeneratedProgram> {
   }
 
   // (Expression (, Expression)*)?
-  private List<Expression<String>> genArguments(SourceOfRandomness random) {
+  private List<Expression<Nameable>> genArguments(SourceOfRandomness random) {
     int n = nextArity(random, 3);
-    List<Expression<String>> ret = new ArrayList<>(n);
+    List<Expression<Nameable>> ret = new ArrayList<>(n);
     for (int i = 0; i < n; ++i) {
       ret.add(genExpression(random));
     }


### PR DESCRIPTION
Add Nameable interface, so we don't have to rely on Object's toString() method. Also add `Definition` and `Ref` classes for name analysis.