### PR TITLE
Squiggly underline

### DIFF
--- a/src/main/java/minijava/Cli.java
+++ b/src/main/java/minijava/Cli.java
@@ -73,7 +73,11 @@ class Cli {
       err.println("error: access to file '" + path + "' was denied");
       return 1;
     } catch (MJError e) {
-      err.println(e.getMessage());
+      try {
+        err.println(e.getSourceReferencingMessage(Files.readAllLines(path)));
+      } catch (IOException io) {
+        err.println(e.getMessage());
+      }
       return 1;
     } catch (NoSuchFileException e) {
       err.println("error: file '" + path + "' doesn't exist");

--- a/src/main/java/minijava/MJError.java
+++ b/src/main/java/minijava/MJError.java
@@ -1,5 +1,7 @@
 package minijava;
 
+import java.util.List;
+
 /** Basic error class in this project. */
 public class MJError extends RuntimeException {
 
@@ -9,5 +11,9 @@ public class MJError extends RuntimeException {
 
   public MJError(String message) {
     super(message);
+  }
+
+  public String getSourceReferencingMessage(List<String> sourceFile) {
+    return getMessage();
   }
 }

--- a/src/main/java/minijava/lexer/Lexer.java
+++ b/src/main/java/minijava/lexer/Lexer.java
@@ -106,7 +106,7 @@ public class Lexer implements Iterator<Token> {
             String.format("Unsupported character with code %d", ch));
       }
       if (ch == '\n') {
-        column = 0;
+        column = -1;
         line++;
       } else {
         column++;

--- a/src/main/java/minijava/lexer/Lexer.java
+++ b/src/main/java/minijava/lexer/Lexer.java
@@ -70,7 +70,7 @@ public class Lexer implements Iterator<Token> {
   private final InputStream input;
   private int ch = -2;
   private int line = 1;
-  private int column = 0;
+  private int column = -1; // after calling nextChar the first time, this will be 0
   private Token eof;
   private SourcePosition tokenBegin;
 

--- a/src/main/java/minijava/parser/ParserError.java
+++ b/src/main/java/minijava/parser/ParserError.java
@@ -1,6 +1,7 @@
 package minijava.parser;
 
 import java.util.Arrays;
+import java.util.List;
 import minijava.MJError;
 import minijava.token.Terminal;
 import minijava.token.Token;
@@ -8,8 +9,11 @@ import minijava.util.SourceRange;
 
 class ParserError extends MJError {
 
+  public final SourceRange range;
+
   ParserError(SourceRange range, String message) {
     super(String.format("Parser error at %s: %s", range, message));
+    this.range = range;
   }
 
   ParserError(String rule, Terminal expectedTerminal, Token actualToken) {
@@ -17,6 +21,7 @@ class ParserError extends MJError {
         String.format(
             "Parser error at %s parsed via %s: expected %s but got %s",
             actualToken.range, rule, expectedTerminal, actualToken));
+    this.range = actualToken.range;
   }
 
   ParserError(String rule, Terminal expectedTerminal, String expectedValue, Token actualToken) {
@@ -24,6 +29,7 @@ class ParserError extends MJError {
         String.format(
             "Parser error at %s parsed via %s: expected %s with value '%s' but got %s",
             actualToken.range, rule, expectedTerminal, expectedValue, actualToken));
+    this.range = actualToken.range;
   }
 
   ParserError(String rule, Token unexpectedToken, Terminal[] expectedTerminals) {
@@ -35,5 +41,14 @@ class ParserError extends MJError {
             unexpectedToken.terminal,
             unexpectedToken.lexval,
             Arrays.toString(expectedTerminals)));
+    this.range = unexpectedToken.range;
+  }
+
+  @Override
+  public String getSourceReferencingMessage(List<String> sourceFile) {
+    return getMessage()
+        + System.lineSeparator()
+        + System.lineSeparator()
+        + range.annotateSourceFileExcerpt(sourceFile);
   }
 }

--- a/src/main/java/minijava/util/SourceRange.java
+++ b/src/main/java/minijava/util/SourceRange.java
@@ -35,24 +35,40 @@ public class SourceRange {
     StringBuilder sb = new StringBuilder();
     if (begin.line < end.line) {
       // we can only really squiggle at the side
-      int digits = (int) Math.ceil(Math.log10(end.line)) + 1;
+      int digits = (int) Math.floor(Math.log10(end.line)) + 1;
       // recall that SourceRange indexes lines starting with 1
-      int begin = Math.max(this.begin.line - 1, 1);
-      int end = Math.min(this.end.line + 1, sourceFile.size());
+      int begin = Math.max(this.begin.line, 1);
+      int end = Math.min(this.end.line, sourceFile.size());
       for (int i = begin; i <= end; ++i) {
         sb.append(String.format("%" + digits + "d|> %s", i, sourceFile.get(i - 1)));
         sb.append(System.lineSeparator());
       }
     } else {
       assert begin.line == end.line;
-      String prefix = String.format("%d| ", begin.line);
-      int squiggleOffset = prefix.length() + begin.column;
-      int squiggleLength = end.column - begin.column;
-      sb.append(prefix);
-      sb.append(sourceFile.get(begin.line - 1));
-      sb.append(System.lineSeparator());
-      sb.append(Strings.repeat(" ", squiggleOffset));
-      sb.append(Strings.repeat("^", squiggleLength));
+
+      int line0 = begin.line - 1; // recall that lines start with 1
+      if (line0 >= sourceFile.size()) {
+        // squiggle the EOF
+        line0 = sourceFile.size() - 1;
+        String prefix = String.format("%d| ", line0 + 1);
+        sb.append(prefix);
+        String lastLine = sourceFile.get(line0);
+        sb.append(lastLine);
+        sb.append(System.lineSeparator());
+        sb.append(Strings.repeat(" ", prefix.length() + lastLine.length()));
+        sb.append("^");
+        sb.append(System.lineSeparator());
+      } else {
+        String prefix = String.format("%d| ", line0 + 1);
+        sb.append(prefix);
+        int squiggleOffset = prefix.length() + begin.column;
+        int squiggleLength = end.column - begin.column;
+        sb.append(sourceFile.get(line0));
+        sb.append(System.lineSeparator());
+        sb.append(Strings.repeat(" ", squiggleOffset));
+        sb.append(Strings.repeat("^", squiggleLength));
+        sb.append(System.lineSeparator());
+      }
     }
     return sb.toString();
   }

--- a/src/main/java/minijava/util/SourceRange.java
+++ b/src/main/java/minijava/util/SourceRange.java
@@ -3,6 +3,10 @@ package minijava.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import java.util.List;
+
 /**
  * A half-open interval in the concrete syntax, denoting the extent of some syntax element. In
  * particular, @end@ is one beyond the last character of the syntax element.
@@ -25,6 +29,54 @@ public class SourceRange {
 
   public SourceRange(SourcePosition begin, int length) {
     this(begin, begin.moveHorizontal(length));
+  }
+
+  public String annotateSourceFileExcerpt(List<String> sourceFile) {
+    StringBuilder sb = new StringBuilder();
+    if (begin.line < end.line) {
+      // we can only really squiggle at the side
+      int digits = (int) Math.ceil(Math.log10(end.line)) + 1;
+      // recall that SourceRange indexes lines starting with 1
+      int begin = Math.max(this.begin.line - 1, 1);
+      int end = Math.min(this.end.line + 1, sourceFile.size());
+      for (int i = begin; i <= end; ++i) {
+        sb.append(String.format("%" + digits + "d|> %s", i, sourceFile.get(i - 1)));
+        sb.append(System.lineSeparator());
+      }
+    } else {
+      assert begin.line == end.line;
+      String prefix = String.format("%d| ", begin.line);
+      int squiggleOffset = prefix.length() + begin.column;
+      int squiggleLength = end.column - begin.column;
+      sb.append(prefix);
+      sb.append(sourceFile.get(begin.line - 1));
+      sb.append(System.lineSeparator());
+      sb.append(Strings.repeat(" ", squiggleOffset));
+      sb.append(Strings.repeat("^", squiggleLength));
+    }
+    return sb.toString();
+  }
+
+  public String extractFromSourceString(String source) {
+    int line = 1;
+    int column = 0;
+    StringBuilder sb = new StringBuilder();
+    for (char c : Lists.charactersOf(source)) {
+      SourcePosition pos = new SourcePosition(line, column);
+      if (pos.compareTo(begin) >= 0 && pos.compareTo(end) < 0) {
+        sb.append(c);
+      } else if (pos.compareTo(end) >= 0) {
+        break;
+      }
+
+      if (c == '\n') {
+        line++;
+        column = 0;
+      } else {
+        column++;
+      }
+    }
+    return sb.toString();
   }
 
   @Override

--- a/src/main/java/minijava/util/SourceRange.java
+++ b/src/main/java/minijava/util/SourceRange.java
@@ -46,6 +46,7 @@ public class SourceRange {
       assert begin.line == end.line;
 
       int line0 = begin.line - 1; // recall that lines start with 1
+      // I kill myself if I copy&paste even one more line, promise.
       if (line0 >= sourceFile.size()) {
         // squiggle the EOF
         line0 = sourceFile.size() - 1;
@@ -54,17 +55,21 @@ public class SourceRange {
         String lastLine = sourceFile.get(line0);
         sb.append(lastLine);
         sb.append(System.lineSeparator());
-        sb.append(Strings.repeat(" ", prefix.length() + lastLine.length()));
+        int offset = prefix.length() + lastLine.length();
+        String space = (prefix + lastLine).substring(0, offset).replaceAll("\\S", " ");
+        sb.append(space);
         sb.append("^");
         sb.append(System.lineSeparator());
       } else {
         String prefix = String.format("%d| ", line0 + 1);
         sb.append(prefix);
+        String lastLine = sourceFile.get(line0);
+        sb.append(lastLine);
+        sb.append(System.lineSeparator());
         int squiggleOffset = prefix.length() + begin.column;
         int squiggleLength = end.column - begin.column;
-        sb.append(sourceFile.get(line0));
-        sb.append(System.lineSeparator());
-        sb.append(Strings.repeat(" ", squiggleOffset));
+        String space = (prefix + lastLine).substring(0, squiggleOffset).replaceAll("\\S", " ");
+        sb.append(space);
         sb.append(Strings.repeat("^", squiggleLength));
         sb.append(System.lineSeparator());
       }

--- a/src/test/java/minijava/lexer/LexerProperties.java
+++ b/src/test/java/minijava/lexer/LexerProperties.java
@@ -70,8 +70,8 @@ public class LexerProperties {
         break;
       }
 
-      if (pos.compareTo(t.range.end) >= 0) {
-        assert pos.equals(t.range.end);
+      if (pos.compareTo(t.range().end) >= 0) {
+        assert pos.equals(t.range().end);
         String lookedUp = sb.toString();
         String repr = t.terminal.hasLexval() ? t.lexval : t.terminal.string;
         // Some printfs for debugging:
@@ -87,7 +87,7 @@ public class LexerProperties {
         t = actual.get(i);
       }
 
-      if (pos.compareTo(t.range.begin) >= 0) {
+      if (pos.compareTo(t.range().begin) >= 0) {
         sb.append(c);
       }
 

--- a/src/test/java/minijava/lexer/LexerProperties.java
+++ b/src/test/java/minijava/lexer/LexerProperties.java
@@ -4,6 +4,8 @@ import static minijava.token.Terminal.*;
 import static org.jooq.lambda.Seq.seq;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+
 import com.pholser.junit.quickcheck.From;
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.generator.Size;
@@ -11,6 +13,7 @@ import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
 import java.util.List;
 import minijava.token.Terminal;
 import minijava.token.Token;
+import minijava.util.SourcePosition;
 import minijava.util.SourceRange;
 import org.junit.Assert;
 import org.junit.runner.RunWith;
@@ -52,6 +55,49 @@ public class LexerProperties {
     // It should also (maybe?) output the same sequence of strings. Not sure about how long this holds, though
     Assert.assertArrayEquals(
         seq(expected).map(t -> t.lexval).toArray(), seq(actual).map(t -> t.lexval).toArray());
+
+    // SourceRanges should be useful, e.g. to exactly determine where the token came from
+    StringBuilder sb = new StringBuilder();
+    SourcePosition pos = new SourcePosition(1, 0);
+    int i = 0;
+    for (char c : Lists.charactersOf(input)) {
+      if (i >= actual.size()) {
+        break;
+      }
+      Token t = actual.get(i);
+
+      if (t.isOneOf(EOF)) {
+        // has no real source code representation
+        break;
+      }
+
+      if (pos.compareTo(t.range.end) >= 0) {
+        assert pos.equals(t.range.end);
+        String lookedUp = sb.toString();
+        String repr = t.terminal.hasLexval() ? t.lexval : t.terminal.string;
+        // Some printfs for debugging:
+        // System.out.println("repr:     " + repr);
+        // System.out.println("lookedUp: " + lookedUp);
+        Assert.assertEquals(
+            "Lookup via SourceRange should yield the proper String representation", repr, lookedUp);
+        sb = new StringBuilder();
+        i++;
+        if (i >= actual.size()) {
+          break;
+        }
+        t = actual.get(i);
+      }
+
+      if (pos.compareTo(t.range.begin) >= 0) {
+        sb.append(c);
+      }
+
+      if (c == '\n') {
+        pos = new SourcePosition(pos.line + 1, 0);
+      } else {
+        pos = new SourcePosition(pos.line, pos.column + 1);
+      }
+    }
   }
 
   /**
@@ -78,8 +124,6 @@ public class LexerProperties {
           sb.append(' ');
         }
         sb.append(text);
-        maybeAppendWhitespace(sb);
-        maybeAppendComment(sb);
         last = text.charAt(text.length() - 1);
         prev = t;
       }
@@ -89,18 +133,5 @@ public class LexerProperties {
 
   private static boolean isOperator(Token t) {
     return t.isOperator() || (t.terminal == RESERVED && RESERVED_OPERATORS.contains(t.lexval));
-  }
-
-  private void maybeAppendWhitespace(StringBuilder sb) {
-    // TODO
-    // Seq.generate(() -> random.choose(WHITESPACE)).limit(random.nextInt(1, 5)).toList());
-
-  }
-
-  private void maybeAppendComment(StringBuilder sb) {
-    // TODO
-    // Character[] choice =
-    //              Seq.of(WHITESPACE).concat(Seq.of(IDENT_FOLLOWING_CHARS)).toArray(Character[]::new);
-    // asString(Seq.generate(() -> random.choose(choice)).limit(random.nextInt(1, 30)).toList())
   }
 }

--- a/src/test/java/minijava/util/SourceRangeTest.java
+++ b/src/test/java/minijava/util/SourceRangeTest.java
@@ -1,0 +1,58 @@
+package minijava.util;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class SourceRangeTest {
+  private final String sourceFile;
+  private final SourceRange range;
+  private final String expectedAnnotation;
+
+  public SourceRangeTest(String sourceFile, SourceRange range, String expectedAnnotation) {
+    this.sourceFile = sourceFile;
+    this.range = range;
+    this.expectedAnnotation = expectedAnnotation;
+  }
+
+  private static SourceRange sl(int beginLine, int beginColumn, int length) {
+    return new SourceRange(new SourcePosition(beginLine, beginColumn), length);
+  }
+
+  private static SourceRange ml(int beginLine, int beginColumn, int endLine, int endColumn) {
+    return new SourceRange(
+        new SourcePosition(beginLine, beginColumn), new SourcePosition(endLine, endColumn));
+  }
+
+  private static String f(String s) {
+    return String.format(s);
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[][] {
+          {"single line", sl(1, 2, 4), f("1| single line%n     ^^^^%n")},
+          {"beyond eof", sl(2, 0, 1), f("1| beyond eof%n             ^%n")},
+          {f("1%n2%n3%n4"), ml(2, 0, 3, 0), f("2|> 2%n3|> 3%n")},
+          {f("1%n2%n3%n4"), ml(1, 0, 2, 0), f("1|> 1%n2|> 2%n")},
+          {f("1%n2%n3%n4"), ml(4, 0, 5, 0), f("4|> 4%n")},
+        });
+  }
+
+  @Test
+  public void annotateSourceFileExcerpt_correctAnnotations() {
+    String[] lines = sourceFile.split("\\n");
+
+    String actualAnnotation = range.annotateSourceFileExcerpt(Arrays.asList(lines));
+
+    assertThat(actualAnnotation, is(equalTo(expectedAnnotation)));
+  }
+}

--- a/src/test/java/minijava/util/SourceRangeTest.java
+++ b/src/test/java/minijava/util/SourceRangeTest.java
@@ -44,6 +44,11 @@ public class SourceRangeTest {
           {f("1%n2%n3%n4"), ml(2, 0, 3, 0), f("2|> 2%n3|> 3%n")},
           {f("1%n2%n3%n4"), ml(1, 0, 2, 0), f("1|> 1%n2|> 2%n")},
           {f("1%n2%n3%n4"), ml(4, 0, 5, 0), f("4|> 4%n")},
+          {
+            "\t \tsingle line with tabs",
+            sl(1, 3, 4),
+            f("1| \t \tsingle line with tabs%n   \t \t^^^^%n")
+          },
         });
   }
 


### PR DESCRIPTION
For error messages. Example single-line message:
```
$ cd mjtest
$ ../run --print-ast tests/syntax/missing_then.invalid.mj
Parser error at [5:1]-[5:2] parsed via parsePrimaryExpression: unexpected RBRACE with value 'null' expected one of [NULL, FALSE, TRUE, INTEGER_LITERAL, IDENT, THIS, LPAREN, NEW]

5| 	}
   	^
```

Couldn't find an example for showcasing a multi-line message so far, sorry about that...