### PR TITLE
Fixed resetting local variable mappings

### DIFF
--- a/src/main/java/minijava/ir/IREmitter.java
+++ b/src/main/java/minijava/ir/IREmitter.java
@@ -66,12 +66,6 @@ public class IREmitter
    * assigned index. Which is a firm thing.
    */
   private final IdentityHashMap<LocalVariable, Integer> localVarIndexes = new IdentityHashMap<>();
-  /**
-   * The next free local variable index for the localVarIndexes mapping. Is different from the
-   * localVarIndexes.size(), because we don't *really* forget mappings when leaving a block. So, at
-   * the end of a method there might be more than one mapping to the same index.
-   */
-  private int nextFreeLocalVarIndex;
   /** The Basic Block graph of the current function. */
   private Graph graph;
   /**
@@ -195,7 +189,6 @@ public class IREmitter
     construction = new Construction(graph);
 
     localVarIndexes.clear();
-    nextFreeLocalVarIndex = 0;
 
     if (!m.isStatic) {
       connectParametersToIRVariables(m);
@@ -336,12 +329,9 @@ public class IREmitter
 
   @Override
   public Void visitBlock(minijava.ast.Block that) {
-    int oldStackPointer = nextFreeLocalVarIndex;
     for (BlockStatement statement : that.statements) {
       statement.acceptVisitor(this);
     }
-    // implicitly forget about all local variables declared in the block
-    nextFreeLocalVarIndex = oldStackPointer;
     return null;
   }
 
@@ -877,7 +867,7 @@ public class IREmitter
       return localVarIndexes.get(var);
     } else {
       // allocate a new index
-      int free = nextFreeLocalVarIndex++;
+      int free = localVarIndexes.size();
       localVarIndexes.put(var, free);
       return free;
     }

--- a/src/main/java/minijava/ir/NumberOfLocalVariablesVisitor.java
+++ b/src/main/java/minijava/ir/NumberOfLocalVariablesVisitor.java
@@ -1,7 +1,5 @@
 package minijava.ir;
 
-import java.util.ArrayList;
-import java.util.List;
 import minijava.ast.Block;
 import minijava.ast.BlockStatement;
 import minijava.ast.Expression;
@@ -13,20 +11,7 @@ public class NumberOfLocalVariablesVisitor
         BlockStatement.Visitor<Integer> {
   @Override
   public Integer visitBlock(Block that) {
-    int c = 0;
-    List<Integer> localVarNums = new ArrayList<>();
-    for (BlockStatement statement : that.statements) {
-      if (statement instanceof Block
-          || statement instanceof Statement.While
-          || statement instanceof Statement.If) {
-        /* Statements that open a new scope */
-        localVarNums.add(c + statement.acceptVisitor(this));
-      } else {
-        c += statement.acceptVisitor(this);
-      }
-    }
-    localVarNums.add(c);
-    return localVarNums.stream().max(Integer::compare).get();
+    return that.statements.stream().map(s -> s.acceptVisitor(this)).reduce(0, (a, b) -> a + b);
   }
 
   @Override
@@ -36,11 +21,7 @@ public class NumberOfLocalVariablesVisitor
 
   @Override
   public Integer visitIf(Statement.If that) {
-    int elseNum = 0;
-    if (that.else_.isPresent()) {
-      elseNum = that.else_.get().acceptVisitor(this);
-    }
-    return Math.max(that.then.acceptVisitor(this), elseNum);
+    return that.then.acceptVisitor(this) + that.else_.map(e -> e.acceptVisitor(this)).orElse(0);
   }
 
   @Override


### PR DESCRIPTION
Prior to this, the counter would not be reset for `main`. e.g. For 
```
class A {

  public boolean b() {
      return true;
    }

  public static void main(String[] args) {
    A a = new A();
  }
}
```

We would main to determine to have one local var, but assign `a` the index 1, e.g. the second slot. Which leads to out of bounds errors within firm.

Also, when assigning mappings to 
```
class A {
  public static void main(String[] args) {
    if (true) {
      int x = 5;
    } else {
      int x = 3;
    }
  }
}
```
We should assign the index 0 to `x` both times (thus reusing a local var slot), not 0 and 1. Although I'm not sure how this plays with SSA form in firm?!