### PR TITLE
Fixed indexing of array types

### DIFF
--- a/src/main/java/minijava/ir/IREmitter.java
+++ b/src/main/java/minijava/ir/IREmitter.java
@@ -174,7 +174,7 @@ public class IREmitter
       // of the number of elements (which is allowed according
       // to the docs)
       // TODO shouldn't we reuse types for arrays as well?
-      type = new ArrayType(type, 0);
+      type = new PointerType(new ArrayType(type, 0));
     }
     return type;
   }
@@ -619,7 +619,7 @@ public class IREmitter
     minijava.ast.Type elementType =
         new minijava.ast.Type(arrayType.basicType, arrayType.dimension - 1, arrayType.range());
 
-    Node address = construction.newSel(array, index, arrayType.acceptVisitor(this));
+    Node address = construction.newSel(array, index, new ArrayType(visitType(elementType), 0));
 
     // We store val at the absOffset
     storeInCurrentLval = (Node val) -> store(address, val);
@@ -642,7 +642,7 @@ public class IREmitter
 
   @Override
   public Node visitNewObject(Expression.NewObject that) {
-    Type type = that.type.acceptVisitor(this);
+    Type type = visitType(that.type);
     storeInCurrentLval = null;
     Node num = construction.newConst(1, Mode.getP());
     Node size = construction.newSize(Mode.getIs(), type);

--- a/src/main/java/minijava/ir/Types.java
+++ b/src/main/java/minijava/ir/Types.java
@@ -19,8 +19,7 @@ class Types {
     // call Firm.init().
     InitFirm.init();
     // Use 64bit pointers by default
-    // I don't see a reason we should, though.
-    //Mode.setDefaultModeP(Mode.createReferenceMode("_64bit", Mode.Arithmetic.TwosComplement, 64, 1));
+    //Mode.setDefaultModeP(Mode.createReferenceMode("p64", Mode.Arithmetic.TwosComplement, 64, 1));
     INT_TYPE = new PrimitiveType(Mode.getIs());
     BOOLEAN_TYPE = new PrimitiveType(Mode.getBu());
     PTR_TYPE = new PrimitiveType(Mode.getP());


### PR DESCRIPTION
Since `ArrayType(type, 0)` always size 0, `Sel` was not generating any offset calculation code.