### PR TITLE
Fixed a semantic bug

### DIFF
--- a/src/main/java/minijava/semantic/SemanticAnalyzer.java
+++ b/src/main/java/minijava/semantic/SemanticAnalyzer.java
@@ -602,6 +602,7 @@ public class SemanticAnalyzer
       p.type.acceptVisitor(this);
       Expression arg = that.arguments.get(i).acceptVisitor(this);
       checkType(p.type, arg.type, arg.range());
+      that.arguments.set(i, arg);
     }
 
     m.returnType.acceptVisitor(this);


### PR DESCRIPTION
MethodCall arguments where previously not replaced by their resolved Expressions.

This is curcial when any argument hides as a VariableAccess but is a FieldAccess to some field in this really.

```
class A {
  public int i;
  public void m() {
    System.out.println(i);
  }
  public static void main(String[] args) {
    new A().m();
  }
}
```