### PR TITLE
Optimize control flow

### DIFF
--- a/src/main/java/minijava/ir/optimize/ConstantControlFlowOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/ConstantControlFlowOptimizer.java
@@ -1,0 +1,58 @@
+package minijava.ir.optimize;
+
+import firm.BackEdges;
+import firm.Graph;
+import firm.Mode;
+import firm.TargetValue;
+import firm.nodes.*;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Replaces {@link Cond} nodes (or more precisely, their accompanying {@link Proj} nodes) with
+ * {@link Jmp} nodes, if the condition is constant.
+ *
+ * <p>The {@link Proj} node that is no longer relevant is replaced with a {@link Bad} node. A
+ * subsequent run of an {@link Optimizer} that removes such nodes is required.
+ */
+public class ConstantControlFlowOptimizer extends DefaultNodeVisitor implements Optimizer {
+
+  private Graph graph;
+  private Proj trueProj;
+  private Proj falseProj;
+
+  @Override
+  public void optimize(Graph graph) {
+    this.graph = graph;
+    BackEdges.enable(graph);
+    graph.walkTopological(this);
+    BackEdges.disable(graph);
+  }
+
+  @Override
+  public void visit(Cond node) {
+    if (node.getSelector() instanceof Const) {
+      TargetValue condition = ((Const) node.getSelector()).getTarval();
+      determineProjectionNodes(node);
+      if (condition.equals(TargetValue.getBTrue())) {
+        graph.exchange(trueProj, graph.newJmp(node.getBlock()));
+        graph.exchange(falseProj, graph.newBad(Mode.getANY()));
+      } else {
+        graph.exchange(falseProj, graph.newJmp(node.getBlock()));
+        graph.exchange(trueProj, graph.newBad(Mode.getANY()));
+      }
+    }
+  }
+
+  private void determineProjectionNodes(Cond node) {
+    List<Proj> projNodes =
+        StreamSupport.stream(BackEdges.getOuts(node).spliterator(), false)
+            .map(e -> (Proj) e.node)
+            .collect(Collectors.toList());
+    assert projNodes.size() == 2;
+    // TODO: the order of the condition's projection nodes is not documented...
+    trueProj = projNodes.get(0);
+    falseProj = projNodes.get(1);
+  }
+}

--- a/src/main/java/minijava/ir/optimize/UnreachableCodeRemover.java
+++ b/src/main/java/minijava/ir/optimize/UnreachableCodeRemover.java
@@ -7,7 +7,10 @@ public class UnreachableCodeRemover implements Optimizer {
 
   @Override
   public void optimize(Graph graph) {
-    binding_irgopt.remove_unreachable_code(graph.ptr);
+    // first remove Bad nodes we inserted manually (the remove_unreachable_code function doesn't pick them up)
+    binding_irgopt.remove_bads(graph.ptr);
+    binding_irgopt.remove_unreachable_code(
+        graph.ptr); // find and replace unreachable code with Bad nodes
     binding_irgopt.remove_bads(graph.ptr);
   }
 }

--- a/src/main/java/minijava/ir/optimize/UnreachableCodeRemover.java
+++ b/src/main/java/minijava/ir/optimize/UnreachableCodeRemover.java
@@ -1,0 +1,13 @@
+package minijava.ir.optimize;
+
+import firm.Graph;
+import firm.bindings.binding_irgopt;
+
+public class UnreachableCodeRemover implements Optimizer {
+
+  @Override
+  public void optimize(Graph graph) {
+    binding_irgopt.remove_unreachable_code(graph.ptr);
+    binding_irgopt.remove_bads(graph.ptr);
+  }
+}


### PR DESCRIPTION
Adds another Omptimizer that replaces `Cond` nodes with immediate jumps, if the condition is constant (builds upon PR #89).

Example:
```java
  public static void main(String[] main_args) throws IOException {
    Program ast =
        new Parser(
                new Lexer(
                    "class A {"
                        + ""
                        + "public static void main(String[] args) {"
                        + ""
                        + ""
                        + "if (1 > 2) {"
                        + "  System.out.println(1);"
                        + "} else {"
                        + "  System.out.println(0);"
                        + "}"
                        + ""
                        + ""
                        + "}"
                        + ""
                        + ""
                        + "}"))
            .parse();
    ast.acceptVisitor(new SemanticAnalyzer());
    ast.acceptVisitor(new SemanticLinter());
    ast.acceptVisitor(new IREmitter());
    Optimizer opt = new ConstantFolder();
    Optimizer opt2 = new ConstantControlFlowOptimizer();
    Optimizer opt3 = new UnreachableCodeRemover();

    for (Graph graph : firm.Program.getGraphs()) {
      Dump.dumpGraph(graph, "-before-optimization");
      opt.optimize(graph);
      opt2.optimize(graph);
      opt3.optimize(graph);
      Dump.dumpGraph(graph, "-after-optimization");
    }
  }
```