### PR TITLE
White list for google java format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 googleJavaFormat {
     toolVersion '1.1'
-    include 'src'
+    source = sourceSets*.allJava
 }
 
 project(':jFirm') {

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,7 @@ repositories {
 
 googleJavaFormat {
     toolVersion '1.1'
-    exclude 'mjtest'
-    exclude 'jFirm'
-    exclude 'libfirm'
+    include 'src'
 }
 
 project(':jFirm') {


### PR DESCRIPTION
White listing `src` now instead of blacklisting some of the directories. The check is quite annoying when having temporary top-level java files for poking around in the implementation.