### PR TITLE
Normalize expressions

### DIFF
--- a/src/main/java/minijava/Cli.java
+++ b/src/main/java/minijava/Cli.java
@@ -180,6 +180,7 @@ public class Cli {
     Optimizer constantFolder = new ConstantFolder();
     Optimizer controlFlowOptimizer = new ConstantControlFlowOptimizer();
     Optimizer unreachableCodeRemover = new UnreachableCodeRemover();
+    Optimizer expressionNormalizer = new ExpressionNormalizer();
     Optimizer algebraicSimplifier = new AlgebraicSimplifier();
     Optimizer commonSubexpressionElimination = new CommonSubexpressionElimination();
     Optimizer phiOptimizer = new PhiOptimizer();
@@ -187,6 +188,7 @@ public class Cli {
     for (Graph graph : firm.Program.getGraphs()) {
       //Dump.dumpGraph(graph, "before-simplification");
       while (constantFolder.optimize(graph)
+          | expressionNormalizer.optimize(graph)
           | algebraicSimplifier.optimize(graph)
           | commonSubexpressionElimination.optimize(graph)
           | phiOptimizer.optimize(graph)) ;

--- a/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
+++ b/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
@@ -7,6 +7,7 @@ import firm.Mode;
 import firm.nodes.*;
 import java.util.*;
 import minijava.ir.Dominance;
+import minijava.ir.utils.ExtensionalEqualityComparator;
 import org.jooq.lambda.Seq;
 
 /**
@@ -324,28 +325,8 @@ public class CommonSubexpressionElimination extends NodeVisitor.Default implemen
       if (!(obj instanceof HashedNode)) {
         return false;
       }
-      // We have to careful that this doesn't produce false positives!
-      // Otherwise we might change the semantics.
-      return similar(this.node, ((HashedNode) obj).node);
-    }
-
-    private static boolean similar(Node a, Node b) {
-      if (a.equals(b)) {
-        return true;
-      }
-      if (!a.getOpCode().equals(b.getOpCode())) {
-        return false;
-      }
-      if (a.getPredCount() != b.getPredCount()) {
-        return false;
-      }
-      int n = a.getPredCount();
-      for (int i = 0; i < n; ++i) {
-        if (!similar(a.getPred(i), b.getPred(i))) {
-          return false;
-        }
-      }
-      return true;
+      return ExtensionalEqualityComparator.INSTANCE.compare(this.node, ((HashedNode) obj).node)
+          == 0;
     }
 
     @Override

--- a/src/main/java/minijava/ir/optimize/ExpressionNormalizer.java
+++ b/src/main/java/minijava/ir/optimize/ExpressionNormalizer.java
@@ -1,0 +1,57 @@
+package minijava.ir.optimize;
+
+import static org.jooq.lambda.Seq.seq;
+
+import com.google.common.collect.Iterables;
+import firm.Graph;
+import firm.nodes.*;
+import java.util.List;
+import minijava.ir.utils.ExtensionalEqualityComparator;
+
+/**
+ * Orders all operands to a commutative/(anti-)symmetric operator as prescribed by {@link
+ * minijava.ir.utils.ExtensionalEqualityComparator}.
+ */
+public class ExpressionNormalizer extends NodeVisitor.Default implements Optimizer {
+  private boolean hasChanged;
+
+  @Override
+  public boolean optimize(Graph graph) {
+    hasChanged = false;
+    graph.walkPostorder(this);
+    return hasChanged;
+  }
+
+  @Override
+  public void visit(Add node) {
+    hasChanged |= reorderPreds(node);
+  }
+
+  @Override
+  public void visit(Mul node) {
+    hasChanged |= reorderPreds(node);
+  }
+
+  @Override
+  public void visit(Cmp node) {
+    boolean swapped = reorderPreds(node);
+    if (swapped) {
+      hasChanged = true;
+      // we also have to change the relation if it wasn't symmetric.
+      node.setRelation(node.getRelation().inversed());
+    }
+  }
+
+  private static boolean reorderPreds(Node node) {
+    List<Node> preds = seq(node.getPreds()).sorted(ExtensionalEqualityComparator.INSTANCE).toList();
+
+    if (Iterables.elementsEqual(preds, node.getPreds())) {
+      return false;
+    }
+
+    for (int i = 0; i < preds.size(); ++i) {
+      node.setPred(i, preds.get(i));
+    }
+    return true;
+  }
+}

--- a/src/main/java/minijava/ir/utils/ExtensionalEqualityComparator.java
+++ b/src/main/java/minijava/ir/utils/ExtensionalEqualityComparator.java
@@ -1,0 +1,120 @@
+package minijava.ir.utils;
+
+import com.google.common.base.Objects;
+import com.sun.jna.Pointer;
+import firm.Mode;
+import firm.TargetValue;
+import firm.bindings.binding_irnode;
+import firm.nodes.Const;
+import firm.nodes.Node;
+import firm.nodes.NodeVisitor;
+import firm.nodes.Proj;
+import java.util.Comparator;
+
+/**
+ * https://en.wikipedia.org/wiki/Extensionality
+ *
+ * <p>Compares nodes not by their Nr, but by these orderings (in this order of breaking ties):
+ *
+ * <ul>
+ *   <li>{@link Const} nodes are greater than all other nodes
+ *   <li>their OpCode
+ *   <li>their Mode
+ *   <li>their predecessors
+ *   <li>Node specific tie breaking (e.g. `TargetValue`s of `Const` nodes)
+ * </ul>
+ *
+ * <p>Nodes which this comparator reports as equal should be exchangeable (modulo dominance)! It's
+ * crucial that this doesn't yield false positives.
+ */
+public class ExtensionalEqualityComparator implements Comparator<Node> {
+  public static ExtensionalEqualityComparator INSTANCE = new ExtensionalEqualityComparator();
+
+  @Override
+  public int compare(Node o1, Node o2) {
+    if (Objects.equal(o1, o2)) {
+      return 0;
+    }
+
+    Comparator<Node> constNodesLast =
+        (a, b) -> {
+          if (a.getOpCode().equals(b.getOpCode())) {
+            return 0;
+          }
+          return a.getOpCode().equals(binding_irnode.ir_opcode.iro_Const) ? -1 : 1;
+        };
+
+    Comparator<Node> predComparator =
+        (a, b) -> {
+          int cmp = 0;
+          int n = a.getPredCount();
+          for (int i = 0; i < n; ++i) {
+            if (cmp != 0) {
+              return cmp;
+            }
+            cmp = compare(a.getPred(i), b.getPred(i));
+          }
+          return cmp;
+        };
+
+    Comparator<Node> tieBreakingComparator =
+        (a, b) -> {
+          TieBreakingCompareVisitor visitor = new TieBreakingCompareVisitor(b);
+          a.accept(visitor);
+          return visitor.cmp;
+        };
+
+    return Comparator.nullsFirst(
+            constNodesLast
+                .thenComparing(Node::getOpCode)
+                .thenComparing(Node::getPredCount)
+                .thenComparingLong(n -> Pointer.nativeValue(n.getMode().ptr))
+                .thenComparing(predComparator)
+                .thenComparing(tieBreakingComparator))
+        .compare(o1, o2);
+  }
+
+  /**
+   * This visitor kicks in if we now that both nodes
+   *
+   * <p>- are of the same type - have the same mode - have the same pred count - have the same
+   * predecessors
+   *
+   * <p>This is the last possible instance which can reject extensional equality between two nodes.
+   * It is crucial that non-equal nodes are detected here!
+   */
+  private static class TieBreakingCompareVisitor extends NodeVisitor.Default {
+    private int cmp = 0;
+    private final Node other;
+
+    TieBreakingCompareVisitor(Node other) {
+      this.other = other;
+    }
+
+    @Override
+    public void visit(Const node) {
+      TargetValue a = node.getTarval();
+      TargetValue b = ((Const) other).getTarval();
+      if (a.equals(b)) {
+        cmp = 0;
+      } else {
+        if (node.getMode().equals(Mode.getIs())) {
+          cmp = a.asInt() - b.asInt();
+        } else if (node.getMode().equals(Mode.getP())) {
+          cmp = (int) Math.signum(a.asLong() - b.asLong());
+        } else if (node.getMode().equals(Mode.getb())) {
+          cmp = a.equals(TargetValue.getBFalse()) ? -1 : 1;
+        } else if (node.getMode().equals(Mode.getBu())) {
+          cmp = a.asInt() == 0 ? -1 : 1;
+        } else {
+          assert false;
+        }
+      }
+    }
+
+    @Override
+    public void visit(Proj node) {
+      cmp = node.getNum() - ((Proj) other).getNum();
+    }
+  }
+}


### PR DESCRIPTION
This orders arguments to `Add`, `Mul` and `Cmp` nodes in a (hopefully) well-defined order, defined by `ExtensionalEqualityComparator`.