### PR TITLE
Capture side effects of Div and Mod and ripple effects

### DIFF
--- a/src/main/java/minijava/ir/emit/IREmitter.java
+++ b/src/main/java/minijava/ir/emit/IREmitter.java
@@ -360,7 +360,10 @@ public class IREmitter
             binding_ircons.op_pin_state.op_pin_state_pinned);
     // Fetch the result from memory
     assert Div.pnRes == Mod.pnRes;
+    assert Div.pnM == Mod.pnM;
     Node retProj = construction.newProj(divOrMod, Mode.getLs(), Div.pnRes);
+    // Division by zero might overflow, which is a side effect we have to track.
+    construction.setCurrentMem(construction.newProj(divOrMod, Mode.getM(), Div.pnM));
     // Convert it back to int
     return ExpressionIR.fromValue(construction.newConv(retProj, Mode.getIs()));
   }

--- a/src/main/java/minijava/ir/optimize/AlgebraicSimplifier.java
+++ b/src/main/java/minijava/ir/optimize/AlgebraicSimplifier.java
@@ -34,12 +34,10 @@ import java.util.*;
  *   <li>TODO: Integral domain axioms: Distributivity
  * </ul>
  */
-public class AlgebraicSimplifier extends NodeVisitor.Default implements Optimizer {
+public class AlgebraicSimplifier extends BaseOptimizer {
 
   private static final Group ADD = new AddGroup();
   private static final Monoid MUL = new MulMonoid();
-  private Graph graph;
-  private boolean hasChanged;
 
   @Override
   public boolean optimize(Graph graph) {

--- a/src/main/java/minijava/ir/optimize/BaseOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/BaseOptimizer.java
@@ -32,4 +32,9 @@ public abstract class BaseOptimizer extends NodeVisitor.Default implements Optim
       }
     }
   }
+
+  /** Just a helper method, Node.accept(NodeVisitor) flipped. */
+  protected void visit(Node node) {
+    node.accept(this);
+  }
 }

--- a/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
+++ b/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
@@ -8,6 +8,7 @@ import firm.nodes.*;
 import java.util.*;
 import minijava.ir.Dominance;
 import minijava.ir.utils.ExtensionalEqualityComparator;
+import minijava.ir.utils.GraphUtils;
 import org.jooq.lambda.Seq;
 
 /**
@@ -22,7 +23,7 @@ import org.jooq.lambda.Seq;
  * fashion. With that information in place, we can substitute all similar nodes by their dominance
  * root after path compression (yielding a forest of star graphs).
  */
-public class CommonSubexpressionElimination extends NodeVisitor.Default implements Optimizer {
+public class CommonSubexpressionElimination extends BaseOptimizer {
 
   /**
    * We cache HashedNode instances for Nodes we already encountered. This also breaks cycles in the
@@ -43,7 +44,7 @@ public class CommonSubexpressionElimination extends NodeVisitor.Default implemen
     this.hashes.clear();
     this.similarNodes.clear();
     // One postorder traversal should be enough, as we don't handle Phi nodes and thus cycles.
-    graph.walkPostorder(this);
+    GraphUtils.walkPostOrder(graph, this::visit);
     return transform();
   }
 

--- a/src/main/java/minijava/ir/optimize/ConstantControlFlowOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/ConstantControlFlowOptimizer.java
@@ -10,7 +10,6 @@ import firm.nodes.Cond;
 import firm.nodes.Const;
 import firm.nodes.Jmp;
 import firm.nodes.Node;
-import firm.nodes.NodeVisitor;
 import firm.nodes.Proj;
 import java.util.Optional;
 import minijava.ir.Dominance;
@@ -25,17 +24,14 @@ import minijava.ir.utils.ProjPair;
  * <p>The {@link Proj} node that is no longer relevant is replaced with a {@link Bad} node. A
  * subsequent run of an {@link Optimizer} that removes such nodes is required.
  */
-public class ConstantControlFlowOptimizer extends NodeVisitor.Default implements Optimizer {
-
-  private Graph graph;
-  private boolean hasChanged;
+public class ConstantControlFlowOptimizer extends BaseOptimizer {
 
   @Override
   public boolean optimize(Graph graph) {
     this.graph = graph;
     hasChanged = false;
     BackEdges.enable(graph);
-    GraphUtils.walkPostOrder(graph, n -> n.accept(this));
+    GraphUtils.walkPostOrder(graph, this::visit);
     BackEdges.disable(graph);
     return hasChanged;
   }

--- a/src/main/java/minijava/ir/optimize/ConstantFolder.java
+++ b/src/main/java/minijava/ir/optimize/ConstantFolder.java
@@ -1,43 +1,55 @@
 package minijava.ir.optimize;
 
-import com.google.common.collect.Iterables;
+import static org.jooq.lambda.Seq.seq;
+
 import firm.BackEdges;
 import firm.Graph;
+import firm.Mode;
 import firm.TargetValue;
 import firm.nodes.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.stream.StreamSupport;
+import minijava.ir.utils.FirmUtils;
+import minijava.ir.utils.GraphUtils;
 
-public class ConstantFolder extends BaseOptimizer {
+public class ConstantFolder extends NodeVisitor.Default implements Optimizer {
 
   private Map<Node, TargetValue> latticeMap;
-
-  private TargetValue previousValue;
-  private TargetValue newValue;
-  private NodeVisitor phiStrategy;
+  private Graph graph;
+  private boolean hasChanged;
 
   @Override
   public boolean optimize(Graph graph) {
     this.latticeMap = new HashMap<>();
     this.graph = graph;
-    BackEdges.enable(graph);
-    phiStrategy = new SupremumStrategy();
-    fixedPointIteration();
-    phiStrategy = new EqualAndConstantStrategy();
-    fixedPointIteration();
-    boolean changed = replaceConstants();
-    BackEdges.disable(graph);
-    return changed;
+    return FirmUtils.withBackEdges(
+        graph,
+        () -> {
+          do {
+            hasChanged = false;
+            GraphUtils.walkPostOrder(
+                graph,
+                n -> {
+                  if (n.getMode().equals(Mode.getM())) {
+                    // Constant folding does not make sense for side-effects
+                    return;
+                  }
+                  n.accept(this);
+                });
+          } while (hasChanged);
+          return replaceConstants();
+        });
   }
 
   private boolean replaceConstants() {
     boolean nodesChanged = false;
     for (Entry<Node, TargetValue> e : latticeMap.entrySet()) {
       if (!(e.getKey() instanceof Const) && e.getValue().isConstant()) {
+        redirectMem(e.getKey());
         Node constant = graph.newConst(e.getValue());
         Graph.exchange(e.getKey(), constant);
         nodesChanged = true;
@@ -46,21 +58,60 @@ public class ConstantFolder extends BaseOptimizer {
     return nodesChanged;
   }
 
+  /**
+   * Div and Mod have side effects (e.g. division by zero) which are modeled with memory edges. When
+   * constant fold these, we also have to redirect the memory edges.
+   */
+  private void redirectMem(Node node) {
+    Optional<Node> mem = getInputMem(node);
+    Optional<Proj> memProj = getOutputMemProj(node);
+    if (mem.isPresent() && memProj.isPresent()) {
+      for (BackEdges.Edge be : BackEdges.getOuts(memProj.get())) {
+        be.node.setPred(be.pos, mem.get());
+      }
+    }
+  }
+
+  private Optional<Node> getInputMem(Node node) {
+    switch (node.getOpCode()) {
+      case iro_Div:
+        return Optional.of(((Div) node).getMem());
+      case iro_Mod:
+        return Optional.of(((Mod) node).getMem());
+      default:
+        return Optional.empty();
+    }
+  }
+
+  private Optional<Proj> getOutputMemProj(Node node) {
+    return seq(BackEdges.getOuts(node))
+        .map(be -> be.node)
+        .filter(n -> n.getMode().equals(Mode.getM()))
+        .ofType(Proj.class)
+        .findFirst();
+  }
+
+  private TargetValue getValue(Node n) {
+    return latticeMap.getOrDefault(n, TargetValue.getUnknown());
+  }
+
   private boolean isUnknown(Node n) {
-    TargetValue value = latticeMap.get(n);
-    return value == null || value.equals(TargetValue.getUnknown());
+    return getValue(n).equals(TargetValue.getUnknown());
   }
 
   private boolean isConstant(Node n) {
-    TargetValue value = latticeMap.get(n);
-    return value != null && value.isConstant();
+    return getValue(n).isConstant();
+  }
+
+  private boolean isBad(Node n) {
+    return getValue(n).equals(TargetValue.getBad());
   }
 
   /**
    * @param operation Describes how to calculate the constant value of {@code node}, if both {@code
    *     left} and {@code right} are constant. The inputs to this function are the constant values
    *     of {@code left} and {@code right}.
-   * @param node {@link Add}, {@link And}, {@link Div}, ...
+   * @param node {@link Add}, {@link And}, {@link Mul}, ...
    * @param left the left child of {@code node}
    * @param right the right child of {@code node}
    */
@@ -69,22 +120,33 @@ public class ConstantFolder extends BaseOptimizer {
       Node node,
       Node left,
       Node right) {
-    if (isUnknown(left) || isUnknown(right)) {
-      newValue = TargetValue.getUnknown();
-    } else if (isConstant(left) && isConstant(right)) {
-      TargetValue lhs = latticeMap.get(left);
-      TargetValue rhs = latticeMap.get(right);
-      newValue = operation.apply(lhs, rhs);
-    } else {
-      newValue = TargetValue.getBad();
-    }
-    previousValue = latticeMap.put(node, newValue);
-    hasChanged = detectChange();
+    visitBinaryOperationOptional(operation.andThen(Optional::of), node, left, right);
   }
 
-  private boolean detectChange() {
-    return (previousValue == null && !newValue.equals(TargetValue.getUnknown()))
-        || (previousValue != null && !newValue.equals(previousValue));
+  /**
+   * A more specific overload, the {@param operation} of which also allows to return
+   * Optional.empty() in case the result could not be calculated (e.g. division by zero).
+   */
+  private void visitBinaryOperationOptional(
+      BiFunction<TargetValue, TargetValue, Optional<TargetValue>> operation,
+      Node node,
+      Node left,
+      Node right) {
+    if (isBad(left) || isBad(right)) {
+      updateValue(node, TargetValue.getBad());
+    } else if (isUnknown(left) || isUnknown(right)) {
+      updateValue(node, TargetValue.getUnknown());
+    } else {
+      assert isConstant(left) && isConstant(right);
+      TargetValue lhs = getValue(left);
+      TargetValue rhs = getValue(right);
+      updateValue(node, operation.apply(lhs, rhs).orElse(TargetValue.getBad()));
+    }
+  }
+
+  @Override
+  public void defaultVisit(Node n) {
+    updateValue(n, TargetValue.getBad());
   }
 
   @Override
@@ -101,7 +163,6 @@ public class ConstantFolder extends BaseOptimizer {
   public void visit(Cmp node) {
     visitBinaryOperation(
         (lhs, rhs) -> {
-          // TODO: not sure how contains works, write tests for this!
           if (lhs.compare(rhs).contains(node.getRelation())) {
             return TargetValue.getBTrue();
           } else {
@@ -115,9 +176,7 @@ public class ConstantFolder extends BaseOptimizer {
 
   @Override
   public void visit(Const node) {
-    newValue = node.getTarval();
-    previousValue = latticeMap.put(node, newValue);
-    hasChanged = detectChange();
+    updateValue(node, node.getTarval());
   }
 
   @Override
@@ -127,7 +186,16 @@ public class ConstantFolder extends BaseOptimizer {
 
   @Override
   public void visit(Div node) {
-    visitBinaryOperation((lhs, rhs) -> lhs.div(rhs), node, node.getLeft(), node.getRight());
+    visitBinaryOperationOptional(
+        (lhs, rhs) -> {
+          if (rhs.isNull()) {
+            return Optional.empty();
+          }
+          return Optional.of(lhs.div(rhs));
+        },
+        node,
+        node.getLeft(),
+        node.getRight());
   }
 
   @Override
@@ -143,21 +211,35 @@ public class ConstantFolder extends BaseOptimizer {
    */
   private void visitUnaryOperation(
       Function<TargetValue, TargetValue> operation, Node node, Node child) {
-    if (isUnknown(child)) {
-      newValue = TargetValue.getUnknown();
+    if (isBad(child)) {
+      updateValue(node, TargetValue.getBad());
+    } else if (isUnknown(child)) {
+      updateValue(node, TargetValue.getUnknown());
     } else if (isConstant(child)) {
-      TargetValue value = latticeMap.get(child);
-      newValue = operation.apply(value);
-    } else {
-      newValue = TargetValue.getBad();
+      updateValue(node, operation.apply(getValue(child)));
     }
-    previousValue = latticeMap.put(node, newValue);
-    hasChanged = detectChange();
+  }
+
+  private void updateValue(Node node, TargetValue newValue) {
+    TargetValue previousValue = latticeMap.put(node, newValue);
+    if (previousValue == null) {
+      previousValue = TargetValue.getUnknown();
+    }
+    hasChanged |= !newValue.equals(previousValue);
   }
 
   @Override
   public void visit(Mod node) {
-    visitBinaryOperation((lhs, rhs) -> lhs.mod(rhs), node, node.getLeft(), node.getRight());
+    visitBinaryOperationOptional(
+        (lhs, rhs) -> {
+          if (rhs.isNull()) {
+            return Optional.empty();
+          }
+          return Optional.of(lhs.mod(rhs));
+        },
+        node,
+        node.getLeft(),
+        node.getRight());
   }
 
   @Override
@@ -177,7 +259,11 @@ public class ConstantFolder extends BaseOptimizer {
 
   @Override
   public void visit(Phi node) {
-    phiStrategy.visit(node);
+    TargetValue newValue =
+        seq(node.getPreds())
+            .map(this::getValue)
+            .reduce(TargetValue.getUnknown(), ConstantFolder::supremum);
+    updateValue(node, newValue);
   }
 
   @Override
@@ -205,18 +291,6 @@ public class ConstantFolder extends BaseOptimizer {
     visitBinaryOperation((lhs, rhs) -> lhs.sub(rhs), node, node.getLeft(), node.getRight());
   }
 
-  private class SupremumStrategy extends NodeVisitor.Default {
-    @Override
-    public void visit(Phi node) {
-      newValue =
-          StreamSupport.stream(node.getPreds().spliterator(), false)
-              .map(n -> latticeMap.getOrDefault(n, TargetValue.getUnknown()))
-              .reduce(TargetValue.getUnknown(), (a, b) -> supremum(a, b));
-      previousValue = latticeMap.put(node, newValue);
-      hasChanged = detectChange();
-    }
-  }
-
   private static TargetValue supremum(TargetValue a, TargetValue b) {
     if (a.equals(b)) {
       return a; // or b
@@ -228,31 +302,5 @@ public class ConstantFolder extends BaseOptimizer {
       return a;
     }
     return TargetValue.getBad();
-  }
-
-  private class EqualAndConstantStrategy extends NodeVisitor.Default {
-    @Override
-    public void visit(Phi node) {
-      Node first = Iterables.getFirst(node.getPreds(), null);
-      if (first == null) {
-        // Phi node has no inputs
-        newValue = TargetValue.getBad();
-      } else {
-        // Phi node has at least 'first' as input
-        TargetValue firstValue = latticeMap.getOrDefault(first, TargetValue.getUnknown());
-        boolean allInputsAreEqual =
-            StreamSupport.stream(node.getPreds().spliterator(), false)
-                .skip(1)
-                .map(n -> latticeMap.getOrDefault(n, TargetValue.getUnknown()))
-                .allMatch(value -> value.equals(firstValue));
-        if (allInputsAreEqual && firstValue.isConstant()) {
-          newValue = firstValue;
-        } else {
-          newValue = TargetValue.getBad();
-        }
-      }
-      previousValue = latticeMap.put(node, newValue);
-      hasChanged = detectChange();
-    }
   }
 }

--- a/src/main/java/minijava/ir/optimize/ConstantFolder.java
+++ b/src/main/java/minijava/ir/optimize/ConstantFolder.java
@@ -2,7 +2,7 @@ package minijava.ir.optimize;
 
 import static org.jooq.lambda.Seq.seq;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import firm.BackEdges;
 import firm.Graph;
 import firm.Mode;
@@ -21,7 +21,7 @@ import minijava.ir.utils.GraphUtils;
 public class ConstantFolder extends BaseOptimizer {
 
   private static final Set<Mode> HANDLED_MODES =
-      Sets.newHashSet(Mode.getBu(), Mode.getb(), Mode.getIs(), Mode.getLs());
+      ImmutableSet.of(Mode.getBu(), Mode.getb(), Mode.getIs(), Mode.getLs());
   private Map<Node, TargetValue> latticeMap;
 
   @Override

--- a/src/main/java/minijava/ir/optimize/ExpressionNormalizer.java
+++ b/src/main/java/minijava/ir/optimize/ExpressionNormalizer.java
@@ -7,18 +7,18 @@ import firm.Graph;
 import firm.nodes.*;
 import java.util.List;
 import minijava.ir.utils.ExtensionalEqualityComparator;
+import minijava.ir.utils.GraphUtils;
 
 /**
  * Orders all operands to a commutative/(anti-)symmetric operator as prescribed by {@link
  * minijava.ir.utils.ExtensionalEqualityComparator}.
  */
-public class ExpressionNormalizer extends NodeVisitor.Default implements Optimizer {
-  private boolean hasChanged;
+public class ExpressionNormalizer extends BaseOptimizer {
 
   @Override
   public boolean optimize(Graph graph) {
     hasChanged = false;
-    graph.walkPostorder(this);
+    GraphUtils.walkPostOrder(graph, this::visit);
     return hasChanged;
   }
 

--- a/src/main/java/minijava/ir/optimize/FloatInTransformation.java
+++ b/src/main/java/minijava/ir/optimize/FloatInTransformation.java
@@ -1,17 +1,9 @@
 package minijava.ir.optimize;
 
-import static firm.bindings.binding_irnode.ir_opcode.iro_Address;
-import static firm.bindings.binding_irnode.ir_opcode.iro_Anchor;
-import static firm.bindings.binding_irnode.ir_opcode.iro_Block;
-import static firm.bindings.binding_irnode.ir_opcode.iro_Const;
-import static firm.bindings.binding_irnode.ir_opcode.iro_End;
-import static firm.bindings.binding_irnode.ir_opcode.iro_Jmp;
-import static firm.bindings.binding_irnode.ir_opcode.iro_Phi;
-import static firm.bindings.binding_irnode.ir_opcode.iro_Proj;
-import static firm.bindings.binding_irnode.ir_opcode.iro_Start;
+import static firm.bindings.binding_irnode.ir_opcode.*;
 import static org.jooq.lambda.Seq.seq;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import firm.BackEdges;
 import firm.Graph;
 import firm.Mode;
@@ -37,7 +29,7 @@ public class FloatInTransformation extends BaseOptimizer {
    * Const need to stay in the start block.
    */
   private static final Set<ir_opcode> DONT_OPTIMIZE =
-      Sets.newHashSet(
+      ImmutableSet.of(
           iro_Block,
           iro_Phi,
           iro_Address,

--- a/src/main/java/minijava/ir/optimize/FloatInTransformation.java
+++ b/src/main/java/minijava/ir/optimize/FloatInTransformation.java
@@ -18,7 +18,6 @@ import firm.Mode;
 import firm.bindings.binding_irnode.ir_opcode;
 import firm.nodes.Block;
 import firm.nodes.Node;
-import firm.nodes.NodeVisitor;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -31,7 +30,7 @@ import org.jooq.lambda.tuple.Tuple2;
  * Floats definitions as near as possible to their uses, to lower register pressure and enable
  * common subexpression elimination to kick in once more.
  */
-public class FloatInTransformation extends NodeVisitor.Default implements Optimizer {
+public class FloatInTransformation extends BaseOptimizer {
 
   /**
    * Blocks can't be moved to another block, Phis are inherently tied to their block, Address and
@@ -49,15 +48,13 @@ public class FloatInTransformation extends NodeVisitor.Default implements Optimi
           iro_Anchor,
           iro_Proj);
 
-  private boolean hasChanged;
-
   @Override
   public boolean optimize(Graph graph) {
     //Cli.dumpGraphIfNeeded(graph, "before-float-in");
     boolean hasChangedAtAll = false;
     do {
       hasChanged = false;
-      GraphUtils.walkFromNodeDepthFirst(graph.getEnd(), n -> {}, n -> n.accept(this));
+      GraphUtils.walkPostOrder(graph, this::visit);
       hasChangedAtAll |= hasChanged;
     } while (hasChanged);
     //Cli.dumpGraphIfNeeded(graph, "after-float-in");

--- a/src/main/java/minijava/ir/optimize/Inliner.java
+++ b/src/main/java/minijava/ir/optimize/Inliner.java
@@ -1,26 +1,15 @@
 package minijava.ir.optimize;
 
-import static firm.bindings.binding_irnode.ir_opcode.iro_Address;
-import static firm.bindings.binding_irnode.ir_opcode.iro_Const;
-import static firm.bindings.binding_irnode.ir_opcode.iro_Phi;
+import static firm.bindings.binding_irnode.ir_opcode.*;
 import static org.jooq.lambda.Seq.seq;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import firm.BackEdges;
 import firm.Graph;
 import firm.MethodType;
 import firm.Mode;
 import firm.bindings.binding_irnode.ir_opcode;
-import firm.nodes.Address;
-import firm.nodes.Block;
-import firm.nodes.Call;
-import firm.nodes.End;
-import firm.nodes.Jmp;
-import firm.nodes.Node;
-import firm.nodes.Phi;
-import firm.nodes.Proj;
-import firm.nodes.Return;
-import firm.nodes.Start;
+import firm.nodes.*;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -31,7 +20,7 @@ import org.jooq.lambda.tuple.Tuple2;
 
 public class Inliner extends BaseOptimizer {
   private static final Set<ir_opcode> ALWAYS_IN_START_BLOCK =
-      Sets.newHashSet(iro_Const, iro_Address);
+      ImmutableSet.of(iro_Const, iro_Address);
   private final ProgramMetrics metrics;
   private final Set<Call> callsToInline = new HashSet<>();
 

--- a/src/main/java/minijava/ir/optimize/Inliner.java
+++ b/src/main/java/minijava/ir/optimize/Inliner.java
@@ -28,7 +28,6 @@ public class Inliner extends BaseOptimizer {
    */
   private static final int MAX_LEAF_SIZE_TO_ALWAYS_INLINE = 80;
 
->>>>>>> master
   private final ProgramMetrics metrics;
   private final Set<Call> callsToInline = new HashSet<>();
 

--- a/src/main/java/minijava/ir/optimize/JmpBlockRemover.java
+++ b/src/main/java/minijava/ir/optimize/JmpBlockRemover.java
@@ -8,28 +8,25 @@ import firm.Graph;
 import firm.nodes.Block;
 import firm.nodes.Jmp;
 import firm.nodes.Node;
+import firm.nodes.NodeVisitor;
 import java.util.List;
 import java.util.stream.Collectors;
 import minijava.ir.utils.GraphUtils;
 
 /** Removes {@link Block} nodes that contain a single {@link Jmp} node and nothing else. */
-public class JmpBlockRemover extends BaseOptimizer {
+public class JmpBlockRemover extends NodeVisitor.Default implements Optimizer {
+
+  private Graph graph;
+  private boolean hasChanged;
 
   @Override
   public boolean optimize(Graph graph) {
     this.graph = graph;
+    this.hasChanged = false;
     BackEdges.enable(graph);
-    boolean hasChangedAtAll = false;
-    int i = 0;
-    do {
-      i++;
-      this.hasChanged = false;
-      GraphUtils.walkReversePostOrder(graph, n -> n.accept(this));
-      hasChangedAtAll |= hasChanged;
-    } while (hasChanged);
+    GraphUtils.walkReversePostOrder(graph, n -> n.accept(this));
     BackEdges.disable(graph);
-    assert i <= 2;
-    return hasChangedAtAll;
+    return hasChanged;
   }
 
   @Override

--- a/src/main/java/minijava/ir/optimize/JmpBlockRemover.java
+++ b/src/main/java/minijava/ir/optimize/JmpBlockRemover.java
@@ -10,6 +10,7 @@ import firm.nodes.Jmp;
 import firm.nodes.Node;
 import java.util.List;
 import java.util.stream.Collectors;
+import minijava.ir.utils.GraphUtils;
 
 /** Removes {@link Block} nodes that contain a single {@link Jmp} node and nothing else. */
 public class JmpBlockRemover extends BaseOptimizer {
@@ -17,11 +18,18 @@ public class JmpBlockRemover extends BaseOptimizer {
   @Override
   public boolean optimize(Graph graph) {
     this.graph = graph;
-    this.hasChanged = false;
     BackEdges.enable(graph);
-    graph.walkPostorder(this);
+    boolean hasChangedAtAll = false;
+    int i = 0;
+    do {
+      i++;
+      this.hasChanged = false;
+      GraphUtils.walkReversePostOrder(graph, n -> n.accept(this));
+      hasChangedAtAll |= hasChanged;
+    } while (hasChanged);
     BackEdges.disable(graph);
-    return hasChanged;
+    assert i <= 2;
+    return hasChangedAtAll;
   }
 
   @Override

--- a/src/main/java/minijava/ir/optimize/JmpBlockRemover.java
+++ b/src/main/java/minijava/ir/optimize/JmpBlockRemover.java
@@ -8,23 +8,19 @@ import firm.Graph;
 import firm.nodes.Block;
 import firm.nodes.Jmp;
 import firm.nodes.Node;
-import firm.nodes.NodeVisitor;
 import java.util.List;
 import java.util.stream.Collectors;
 import minijava.ir.utils.GraphUtils;
 
 /** Removes {@link Block} nodes that contain a single {@link Jmp} node and nothing else. */
-public class JmpBlockRemover extends NodeVisitor.Default implements Optimizer {
-
-  private Graph graph;
-  private boolean hasChanged;
+public class JmpBlockRemover extends BaseOptimizer {
 
   @Override
   public boolean optimize(Graph graph) {
     this.graph = graph;
     this.hasChanged = false;
     BackEdges.enable(graph);
-    GraphUtils.walkReversePostOrder(graph, n -> n.accept(this));
+    GraphUtils.walkReversePostOrder(graph, this::visit);
     BackEdges.disable(graph);
     return hasChanged;
   }

--- a/src/main/java/minijava/ir/optimize/PhiOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/PhiOptimizer.java
@@ -11,7 +11,7 @@ import firm.nodes.Phi;
  * Performs various optimizations special to Phi nodes. Currently, there are transformations for
  *
  * <ul>
- *   <li>Removing Phi nodes where all predecessor are the same.
+ *   <li>Removing Phi nodes where all predecessors are the same.
  * </ul>
  */
 public class PhiOptimizer extends BaseOptimizer {

--- a/src/main/java/minijava/ir/optimize/PhiOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/PhiOptimizer.java
@@ -6,6 +6,7 @@ import static org.jooq.lambda.Seq.seq;
 import firm.Graph;
 import firm.nodes.Node;
 import firm.nodes.Phi;
+import minijava.ir.utils.GraphUtils;
 
 /**
  * Performs various optimizations special to Phi nodes. Currently, there are transformations for
@@ -20,7 +21,7 @@ public class PhiOptimizer extends BaseOptimizer {
   public boolean optimize(Graph graph) {
     this.graph = graph;
     this.hasChanged = false;
-    graph.walkTopological(this);
+    GraphUtils.walkPostOrder(graph, this::visit);
     return hasChanged;
   }
 

--- a/src/main/java/minijava/ir/optimize/PhiOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/PhiOptimizer.java
@@ -1,13 +1,17 @@
 package minijava.ir.optimize;
 
+import static firm.bindings.binding_irnode.ir_opcode.iro_Phi;
+import static org.jooq.lambda.Seq.seq;
+
 import firm.Graph;
+import firm.nodes.Node;
 import firm.nodes.Phi;
 
 /**
  * Performs various optimizations special to Phi nodes. Currently, there are transformations for
  *
  * <ul>
- *   <li>Removing Phi nodes with only a single predecessor
+ *   <li>Removing Phi nodes where all predecessor are the same.
  * </ul>
  */
 public class PhiOptimizer extends BaseOptimizer {
@@ -26,10 +30,32 @@ public class PhiOptimizer extends BaseOptimizer {
   }
 
   private void removeSinglePredPhi(Phi node) {
-    // If a block only has a single predecessor, the predecessor's block is the immediate dominator.
-    // We can freely use any values from that block, including the predecessor itself, with which we replace the Phi.
-    if (node.getPredCount() == 1) {
-      Graph.exchange(node, node.getPred(0));
+    // If the predecessor edges of a Phi all point to the same node, we can eliminate that Phi.
+    // That's because the definition block must domininate every predecessor, so by definition
+    // of dominance it also dominates this block.
+    // There is the special case where a Phi has Phis as a predecessor. We can't really do this
+    // transformation if both Phis are in the same block. But if that would be the case,
+    // there is no way we could enter this block, because that phi won't be visible
+    // from any predecessor, at least not on the first iteration.
+    long distinctPreds = seq(node.getPreds()).distinct().count();
+    boolean isOnlyPred = distinctPreds == 1;
+    if (!isOnlyPred) {
+      return;
     }
+    Node pred = node.getPred(0);
+
+    boolean isKeptAlive = seq(graph.getEnd().getPreds()).contains(node);
+    //System.out.println(isKeptAlive);
+    if (isKeptAlive) {
+      // We could try to find the predecessor index in End and remove it by replacing it with a Bad,
+      // but that just seems like too much trouble for no gain: Kept alive nodes are (probably) always
+      // Phi[loop] of mode M, which are erased by code gen.
+      return;
+    }
+
+    //System.out.println(node.getGraph() + ": node " + node + ". " + Iterables.toString(seq(node.getPreds())));
+    assert pred.getOpCode() != iro_Phi || !pred.getBlock().equals(node.getBlock());
+    Graph.exchange(node, pred);
+    hasChanged = true;
   }
 }

--- a/src/main/java/minijava/ir/utils/GraphUtils.java
+++ b/src/main/java/minijava/ir/utils/GraphUtils.java
@@ -68,6 +68,17 @@ public class GraphUtils {
     return connected[0];
   }
 
+  /**
+   * Computes a topological sorting on the predecessor (!) graph. This is the right traversal for
+   * things that change control flow. You can assume (except for back edges) that the nodes are
+   * untouched when visited, e.g. predecessors are exactly the same as when the walk was started.
+   */
+  public static void walkReversePostOrder(Graph graph, Consumer<Node> visitNode) {
+    ArrayDeque<Node> stack = new ArrayDeque<>();
+    walkPostOrder(graph, stack::addFirst);
+    stack.forEach(visitNode);
+  }
+
   public static void walkPostOrder(Graph graph, Consumer<Node> visitNode) {
     walkFromNodeDepthFirst(graph.getEnd(), n -> {}, visitNode);
   }


### PR DESCRIPTION
I'm sorry that this is yet again an amalgamation of multiple possible PRs:

I finally came around to fix side effects for `Div` and `Mod`. Consider this program:

```
class div_by_zero_side_effect {
        public static void main(String[] args) {
                int j = 5 / 0;
                System.out.println(0);
        }
}
```

On current master, this will print 0 and exit successfully, because we didn't `setCurrentMem` when emitting the `Div`. Since `j` is dead, the `Div` is not reachable at all from the `End` node and thus there will be no code emitted, although we certainly need to preserve semantics and throw an exception here! That's why we need the memory edge.

So I did the trivial change to `IREmitter`, but that broke `ConstantFolder`. After having understood the problem (we'd have to redirect memory edges when exchanging nodes), I noticed strange behavior: Mode M nodes were folded. And so I chased the rabbit down the hole... Of particular note is the `defaultVisit` override, which assumes `Bad` values for all unhandled nodes. Previously those had `Unknown` as values, rendering the Analysis unsound. A fortunate side-effect is that I got rid of the two different `PhiStrategy`s this way.

I again noticed, that `graph.walk*` just doesn't work and also that the visit order wasn't what we wanted for `JmpBlockRemover`, so I replaced it with a call to `GraphUtils.walkReversePostOrder`.

The changes to `PhiOptimizer` are rather modest and were the original motivation for the PR.

@parttimenerd Is it somehow possible to write tests in `mjtest` that test for errors? Otherwise I don't see how we could reliably test if we preserve error behavior...