### PR TITLE
Loads don't alias with any other loads now

### DIFF
--- a/src/main/java/minijava/Compiler.java
+++ b/src/main/java/minijava/Compiler.java
@@ -103,6 +103,7 @@ public class Compiler {
                 expressionNormalizer,
                 algebraicSimplifier,
                 phiOptimizer,
+                aliasAnalyzer,
                 loadStoreOptimizer,
                 controlFlowOptimizer)
             .add(aliasAnalyzer)

--- a/src/main/java/minijava/ir/optimize/AliasAnalyzer.java
+++ b/src/main/java/minijava/ir/optimize/AliasAnalyzer.java
@@ -152,6 +152,10 @@ public class AliasAnalyzer extends BaseOptimizer {
 
   @Override
   public void defaultVisit(Node node) {
+    mergeMemoryFromPreds(node);
+  }
+
+  private void mergeMemoryFromPreds(Node node) {
     // We have to merge all preceding memory values
     Memory memory =
         seq(node.getPreds()).map(this::getMemory).foldLeft(Memory.empty(), Memory::mergeWith);
@@ -160,7 +164,7 @@ public class AliasAnalyzer extends BaseOptimizer {
 
   @Override
   public void visit(Phi node) {
-    defaultVisit(node);
+    mergeMemoryFromPreds(node);
 
     if (node.getMode().equals(Mode.getP())) {
       Set<IndirectAccess> pointsTo =
@@ -171,7 +175,7 @@ public class AliasAnalyzer extends BaseOptimizer {
 
   @Override
   public void visit(Member node) {
-    defaultVisit(node);
+    mergeMemoryFromPreds(node);
 
     int offset = node.getEntity().getOffset();
     Type fieldType = node.getEntity().getType();
@@ -190,7 +194,7 @@ public class AliasAnalyzer extends BaseOptimizer {
 
   @Override
   public void visit(Sel node) {
-    defaultVisit(node);
+    mergeMemoryFromPreds(node);
 
     ArrayType arrayType = (ArrayType) node.getType();
     int offset =
@@ -254,7 +258,7 @@ public class AliasAnalyzer extends BaseOptimizer {
 
   @Override
   public void visit(Load load) {
-    defaultVisit(load);
+    mergeMemoryFromPreds(load);
     // A load doesn't change memory, but we can say something about the loaded value
     Memory memory = getMemory(load);
     Set<IndirectAccess> pointsTo = getPointsTo(load.getPtr());
@@ -266,7 +270,7 @@ public class AliasAnalyzer extends BaseOptimizer {
 
   @Override
   public void visit(Store store) {
-    defaultVisit(store);
+    mergeMemoryFromPreds(store);
     // Store is only interesting for its side effects. Yet we record the pointed to set,
     // which means in this case 'might be modified by'.
     Set<IndirectAccess> ptrPointsTo = getPointsTo(store.getPtr());
@@ -283,7 +287,7 @@ public class AliasAnalyzer extends BaseOptimizer {
 
   @Override
   public void visit(Proj proj) {
-    defaultVisit(proj);
+    mergeMemoryFromPreds(proj);
     if (proj.getPred().getOpCode() == iro_Proj) {
       transferProjOnProj(proj, (Proj) proj.getPred());
     } else {

--- a/src/main/java/minijava/ir/optimize/BaseOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/BaseOptimizer.java
@@ -24,6 +24,7 @@ public abstract class BaseOptimizer extends NodeVisitor.Default implements Optim
    * from the outputs of the previous visiting.
    */
   protected boolean fixedPointIteration(Collection<Node> initialWorklist) {
+    assert graph != null : "No graph instance set";
     return FirmUtils.withBackEdges(
         graph,
         () -> {

--- a/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
+++ b/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
@@ -338,9 +338,6 @@ public class CommonSubexpressionElimination extends BaseOptimizer {
     addHashedNode(hashed);
     HashedNode old = hashes.put(node, hashed);
     if (!hashed.equals(old)) {
-      if (node.getNr() == 419) {
-        System.out.println("Changed: " + old + " new: " + hashed);
-      }
       hasChanged = true;
     }
   }

--- a/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
+++ b/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
@@ -4,13 +4,40 @@ import static org.jooq.lambda.Seq.seq;
 
 import firm.Graph;
 import firm.Mode;
-import firm.nodes.*;
-import java.util.*;
+import firm.nodes.Add;
+import firm.nodes.Address;
+import firm.nodes.And;
+import firm.nodes.Block;
+import firm.nodes.Cmp;
+import firm.nodes.Cond;
+import firm.nodes.Const;
+import firm.nodes.Conv;
+import firm.nodes.Div;
+import firm.nodes.Load;
+import firm.nodes.Member;
+import firm.nodes.Minus;
+import firm.nodes.Mod;
+import firm.nodes.Mul;
+import firm.nodes.Node;
+import firm.nodes.Not;
+import firm.nodes.Or;
+import firm.nodes.Proj;
+import firm.nodes.Sel;
+import firm.nodes.Shl;
+import firm.nodes.Shr;
+import firm.nodes.Shrs;
+import firm.nodes.Size;
+import firm.nodes.Sub;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import minijava.ir.Dominance;
 import minijava.ir.utils.ExtensionalEqualityComparator;
 import minijava.ir.utils.GraphUtils;
 import minijava.ir.utils.NodeUtils;
-import org.jooq.lambda.Seq;
 
 /**
  * Implements Common Subexpression Elimination by hashing node specific values and their
@@ -42,10 +69,11 @@ public class CommonSubexpressionElimination extends BaseOptimizer {
 
   @Override
   public boolean optimize(Graph graph) {
+    this.graph = graph;
     this.hashes.clear();
     this.similarNodes.clear();
     // One postorder traversal should be enough, as we don't handle Phi nodes and thus cycles.
-    GraphUtils.topologicalOrder(graph).forEach(this::visit);
+    fixedPointIteration(GraphUtils.topologicalOrder(graph));
     return transform();
   }
 
@@ -81,6 +109,7 @@ public class CommonSubexpressionElimination extends BaseOptimizer {
     if (redundant.getMode().equals(Mode.getT())) {
       // Nodes such as div and mod return a tuple.
       // We have to merge projs accordingly.
+
       NodeUtils.redirectProjsOnto(redundant, replacement);
       Graph.killNode(redundant);
     } else {
@@ -155,7 +184,7 @@ public class CommonSubexpressionElimination extends BaseOptimizer {
   @Override
   public void defaultVisit(Node node) {
     // This is a safe default, as a nodes hash should be quite unique.
-    hashWithSalt(node.hashCode()).ifPresent(hash -> updateHashMapping(node, hash));
+    updateHashMapping(node, node.hashCode());
   }
 
   @Override
@@ -275,6 +304,13 @@ public class CommonSubexpressionElimination extends BaseOptimizer {
     binaryNode(node);
   }
 
+  @Override
+  public void visit(Load node) {
+    // Since loads aren't really a side effect as much as they impose an ordering on other
+    // side effects, we can perform CSE if ptr and mem preds are equal.
+    binaryNode(node);
+  }
+
   /**
    * Helper method called for all uninteresting (e.g. no relevant discerning state beyond their node
    * type and preds) unary nodes.
@@ -300,12 +336,21 @@ public class CommonSubexpressionElimination extends BaseOptimizer {
   private void updateHashMapping(Node node, int hash) {
     HashedNode hashed = new HashedNode(node, hash);
     addHashedNode(hashed);
-    hashes.put(node, hashed);
+    HashedNode old = hashes.put(node, hashed);
+    if (!hashed.equals(old)) {
+      if (node.getNr() == 419) {
+        System.out.println("Changed: " + old + " new: " + hashed);
+      }
+      hasChanged = true;
+    }
   }
 
   private void addHashedNode(HashedNode hashed) {
     Set<Node> similar =
         similarNodes.containsKey(hashed) ? similarNodes.get(hashed) : new HashSet<>();
+    if (!similar.contains(hashed.node)) {
+      hasChanged = true;
+    }
     similar.add(hashed.node);
     similarNodes.put(hashed, similar);
   }
@@ -315,10 +360,12 @@ public class CommonSubexpressionElimination extends BaseOptimizer {
    * been computed yet (or can't be, e.g. Phis) then we return Optional.empty().
    */
   private Optional<Integer> hashWithSalt(int salt, Node... preds) {
-    // Java really needs `mapM`. /jk
-    Object[] hashedPreds = Seq.of(preds).map(hashes::get).toArray(Object[]::new);
-    if (Seq.of(hashedPreds).contains(null)) {
-      return Optional.empty();
+    Object[] hashedPreds = new Object[preds.length];
+    for (int i = 0; i < preds.length; ++i) {
+      hashedPreds[i] = hashes.get(preds[i]);
+      if (hashedPreds[i] == null) {
+        return Optional.empty();
+      }
     }
     return Optional.of(salt ^ Objects.hash(hashedPreds));
   }

--- a/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
+++ b/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
@@ -357,14 +357,15 @@ public class CommonSubexpressionElimination extends BaseOptimizer {
    * been computed yet (or can't be, e.g. Phis) then we return Optional.empty().
    */
   private Optional<Integer> hashWithSalt(int salt, Node... preds) {
-    Object[] hashedPreds = new Object[preds.length];
+    Object[] hashes = new Object[preds.length + 1];
     for (int i = 0; i < preds.length; ++i) {
-      hashedPreds[i] = hashes.get(preds[i]);
-      if (hashedPreds[i] == null) {
+      hashes[i] = this.hashes.get(preds[i]);
+      if (hashes[i] == null) {
         return Optional.empty();
       }
     }
-    return Optional.of(salt ^ Objects.hash(hashedPreds));
+    hashes[preds.length] = salt;
+    return Optional.of(Objects.hash(hashes));
   }
 
   /**

--- a/src/main/java/minijava/ir/optimize/LoadStoreOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/LoadStoreOptimizer.java
@@ -21,7 +21,7 @@ public class LoadStoreOptimizer extends BaseOptimizer {
   @Override
   public boolean optimize(Graph graph) {
     this.graph = graph;
-    return fixedPointIteration(GraphUtils.reverseTopologicalOrder(graph));
+    return fixedPointIteration(GraphUtils.topologicalOrder(graph));
   }
 
   @Override
@@ -35,6 +35,9 @@ public class LoadStoreOptimizer extends BaseOptimizer {
     Node lastSideEffect = node.getMem().getPred(0);
     switch (lastSideEffect.getOpCode()) {
       case iro_Load:
+        // This will not happen any more. After the AliasAnalyzer, there shouldn't be any
+        // Load-Load dependencies. This case is thus handled by CSE.
+        // I leave it here anyway for when the alias analysis isn't run.
         Load previousLoad = (Load) lastSideEffect;
         if (!previousLoad.getPtr().equals(node.getPtr())) {
           break;

--- a/src/main/java/minijava/ir/optimize/SyncOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/SyncOptimizer.java
@@ -1,23 +1,15 @@
 package minijava.ir.optimize;
 
-import static firm.bindings.binding_irnode.ir_opcode.iro_Phi;
 import static org.jooq.lambda.Seq.seq;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import firm.Graph;
-import firm.bindings.binding_irnode.ir_opcode;
-import firm.nodes.Block;
 import firm.nodes.Node;
 import firm.nodes.Sync;
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.HashSet;
 import java.util.Set;
-import minijava.ir.Dominance;
 import minijava.ir.utils.GraphUtils;
 import minijava.ir.utils.NodeUtils;
-import org.jooq.lambda.Seq;
+import minijava.ir.utils.SideEffects;
 
 /**
  * Performs optimizations special to Sync nodes. Currently, there are transformations for
@@ -39,8 +31,9 @@ public class SyncOptimizer extends BaseOptimizer {
 
   @Override
   public void visit(Sync node) {
-    Set<Node> sinks = findReachabilitySinks(node);
-    Set<Node> modeMs = seq(sinks).map(NodeUtils::projModeMOf).toSet();
+    Set<Node> sourceSuperset = SideEffects.getPreviousSideEffectsOrPhis(node);
+    Set<Node> sources = SideEffects.filterSideEffectSources(sourceSuperset);
+    Set<Node> modeMs = seq(sources).map(NodeUtils::projModeMOf).toSet();
     boolean needToExchangeWithNewNode = !seq(node.getPreds()).toSet().equals(modeMs);
     if (!needToExchangeWithNewNode) {
       return;
@@ -52,61 +45,5 @@ public class SyncOptimizer extends BaseOptimizer {
       Node newSync = graph.newSync(node.getBlock(), seq(modeMs).toArray(Node[]::new));
       Graph.exchange(node, newSync);
     }
-  }
-
-  private static Set<Node> findReachabilitySinks(Sync node) {
-    // We'll use the algorithm http://wiki.c2.com/?GraphSinkDetection.
-    // Note that we won't optimize beyond Phi nodes.
-    Set<Node> relevantNodes = reachableSideEffects(node);
-    Set<Node> possiblySources = new HashSet<>(relevantNodes);
-    for (Node n : relevantNodes) {
-      if (isSink(n)) {
-        continue;
-      }
-      // Any side effect with an incoming edge is not a source
-      getPrecedingSideEffects(n).forEach(possiblySources::removeAll);
-    }
-    return possiblySources;
-  }
-
-  private static Seq<Set<Node>> getPrecedingSideEffects(Node n) {
-    Set<Node> mems;
-    if (n.getOpCode() == iro_Phi) {
-      // We have to be careful to not follow back edges. We might reach actual sources through
-      // them, so that they aren't sources anymore.
-      // So we only return those mems where the blocks aren't dominated by the Phi's.
-      Block phiBlock = (Block) n.getBlock();
-      mems =
-          seq(n.getPreds())
-              .filter(mem -> !Dominance.dominates(phiBlock, (Block) mem.getBlock()))
-              .toSet();
-    } else {
-      // Every other case is simple: Just use the single mem pred at index 0.
-      mems = Sets.newHashSet(n.getPred(0));
-    }
-
-    return seq(mems).map(NodeUtils::getPreviousSideEffects);
-  }
-
-  private static boolean isSink(Node n) {
-    // We don't optimize beyond Phis.
-    return n.getOpCode() == ir_opcode.iro_Start;
-  }
-
-  private static Set<Node> reachableSideEffects(Sync node) {
-    Set<Node> reachable = new HashSet<>();
-    Deque<Node> toVisit = new ArrayDeque<>();
-    toVisit.addAll(NodeUtils.getPreviousSideEffects(node));
-    while (!toVisit.isEmpty()) {
-      Node cur = toVisit.removeFirst();
-      if (reachable.contains(cur)) {
-        continue;
-      }
-      reachable.add(cur);
-      if (!isSink(cur)) {
-        getPrecedingSideEffects(cur).forEach(toVisit::addAll);
-      }
-    }
-    return reachable;
   }
 }

--- a/src/main/java/minijava/ir/utils/ExtensionalEqualityComparator.java
+++ b/src/main/java/minijava/ir/utils/ExtensionalEqualityComparator.java
@@ -9,6 +9,7 @@ import firm.bindings.binding_irnode;
 import firm.bindings.binding_irnode.ir_opcode;
 import firm.nodes.Cmp;
 import firm.nodes.Const;
+import firm.nodes.Load;
 import firm.nodes.Member;
 import firm.nodes.Node;
 import firm.nodes.NodeVisitor;
@@ -141,6 +142,15 @@ public class ExtensionalEqualityComparator implements Comparator<Node> {
     @Override
     public void visit(Proj node) {
       // Two different projs should never be considered equal.
+      cmp = node.getNr() - other.getNr();
+    }
+
+    @Override
+    public void visit(Load node) {
+      Mode otherLoadMode = ((Load) other).getLoadMode();
+      if (node.getLoadMode().equals(otherLoadMode)) {
+        return;
+      }
       cmp = node.getNr() - other.getNr();
     }
 

--- a/src/main/java/minijava/ir/utils/NodeUtils.java
+++ b/src/main/java/minijava/ir/utils/NodeUtils.java
@@ -8,7 +8,6 @@ import static org.jooq.lambda.Seq.seq;
 import static org.jooq.lambda.Seq.zipWithIndex;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.sun.jna.Pointer;
 import firm.BackEdges;
 import firm.Graph;
@@ -142,7 +141,6 @@ public class NodeUtils {
             usedNums.add(((Proj) be.node).getNum());
           }
         });
-    System.out.println(usedNums);
 
     usedNums.forEach(num -> mergeProjsWithNum(newTarget, num));
   }
@@ -154,27 +152,6 @@ public class NodeUtils {
 
   public static Pointer getLink(Node node) {
     return binding_irnode.get_irn_link(node.ptr);
-  }
-
-  /**
-   * Expects {@param modeM} to be a Mem node from which we follow mem edges until we hit a
-   * side-effect node (including Phis). Essentially skips uninteresting Proj M and Sync nodes.
-   */
-  public static Set<Node> getPreviousSideEffects(Node modeM) {
-    assert modeM.getMode().equals(Mode.getM());
-    switch (modeM.getOpCode()) {
-      case iro_Proj:
-        return Sets.newHashSet(modeM.getPred(0));
-      case iro_Phi:
-        return Sets.newHashSet(modeM); // we return Phis themselves
-      case iro_Sync:
-        Set<Node> ret = new HashSet<>();
-        seq(modeM.getPreds()).map(NodeUtils::getPreviousSideEffects).forEach(ret::addAll);
-        return ret;
-      default:
-        LOGGER.warn("Didn't expect a mode M node " + modeM);
-        return Sets.newHashSet(modeM);
-    }
   }
 
   /** Projects out the Mem effect of the passed side effect if necessary. */

--- a/src/main/java/minijava/ir/utils/SideEffects.java
+++ b/src/main/java/minijava/ir/utils/SideEffects.java
@@ -1,0 +1,217 @@
+package minijava.ir.utils;
+
+import static firm.bindings.binding_irnode.ir_opcode.iro_Phi;
+import static firm.bindings.binding_irnode.ir_opcode.iro_Start;
+import static org.jooq.lambda.Seq.seq;
+
+import com.google.common.collect.Sets;
+import firm.Mode;
+import firm.bindings.binding_irnode.ir_opcode;
+import firm.nodes.Block;
+import firm.nodes.Node;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import minijava.ir.Dominance;
+import minijava.ir.optimize.AliasAnalyzer;
+import org.jooq.lambda.Seq;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SideEffects {
+  private static final Logger LOGGER = LoggerFactory.getLogger("SideEffects");
+  private static final int MAX_NUMBER_OF_SYNC_PREDS = 10;
+
+  /**
+   * This is the meat of the Alias transformation. It got somewhat complicated when adding support
+   * for Phi nodes with something like back-tracking.
+   *
+   * @param affectsRoot Determines for a given side effecting node if we can ignore it and continue
+   *     to search its predecessors. This will compare alias classes for overlap in {@link
+   *     AliasAnalyzer}.
+   * @param root The memory nodes from which to start searching for affecting side effects.
+   * @return The set of all last affecting side effects. These may be multiple, because of Sync
+   *     nodes.
+   */
+  public static Set<Node> lastAffectingSideEffects(Predicate<Node> affectsRoot, Node root) {
+    // Assumes that the single mem predecessor is at index 0.
+    Node mem = root.getPred(0);
+    Set<Node> roots = getPreviousSideEffectsOrPhis(mem);
+    Set<Node> visited = Sets.newHashSet(root);
+    Set<Node> sourceSuperset =
+        lastAffectingSideEffectsHelper(affectsRoot, roots, visited).sideEffects;
+    return filterSideEffectSources(sourceSuperset);
+  }
+
+  /**
+   * This is the meat of lastAliasingSideEffects. It got somewhat complicated when adding support
+   * for Phi nodes with something like back-tracking.
+   *
+   * @param canMoveBeyond Determines for a given side effecting node if we can ignore it and
+   *     continue to search its predecessors. This will compare alias classes for overlap in {@link
+   *     AliasAnalyzer}.
+   * @param roots The memory nodes from which to start searching for aliases.
+   * @param originalVisited The set of already visited nodes at the time this call happens.
+   * @return A LastAliasingSideEffectsResult containing the last aliasing side effects and the set
+   *     of nodes visited during the search.
+   */
+  private static LastAliasingSideEffectsResult lastAffectingSideEffectsHelper(
+      Predicate<Node> canMoveBeyond, Set<Node> roots, Set<Node> originalVisited) {
+    Set<Node> ret = new HashSet<>();
+    Set<Node> toVisit = new HashSet<>(roots);
+    Set<Node> visited = new HashSet<>(originalVisited);
+    while (!toVisit.isEmpty()) {
+      Node prevSideEffect = toVisit.iterator().next();
+      toVisit.remove(prevSideEffect);
+      if (visited.contains(prevSideEffect)) {
+        continue;
+      }
+      visited.add(prevSideEffect);
+
+      ir_opcode opCode = prevSideEffect.getOpCode();
+
+      if (opCode == iro_Start) {
+        // We can't extend beyond a Start node.
+        ret.add(prevSideEffect);
+      } else if (opCode == iro_Phi) {
+        // We try to extend beyond that Phi
+        Set<Node> sideEffectsPrecedingPhi =
+            seq(prevSideEffect.getPreds())
+                .map(SideEffects::getPreviousSideEffectsOrPhis)
+                .flatMap(Seq::seq)
+                .toSet();
+        LastAliasingSideEffectsResult extended =
+            lastAffectingSideEffectsHelper(canMoveBeyond, sideEffectsPrecedingPhi, visited);
+        // The extended solution might contain side effects from the current block, reachable
+        // through a back edge. If there is such a node, we can't extend beyond the Phi.
+        // Also, if one of the side effects doesn't dominate the current block, we can't extend.
+        // In other words: All side effects' blocks must be strict dominators of the Phi's block.
+        // Note that it's OK if this returned the node we started from and that case is the
+        // reason we pass along the visited set: So that no node already visited is included (as
+        // we already have them covered).
+        Block phiBlock = (Block) prevSideEffect.getBlock();
+        boolean canExtend =
+            seq(extended.sideEffects)
+                .allMatch(se -> Dominance.strictlyDominates((Block) se.getBlock(), phiBlock));
+        if (!canExtend) {
+          // Just record the Phi.
+          ret.add(prevSideEffect);
+        } else {
+          ret.addAll(extended.sideEffects);
+          // This is only OK now that we covered all those nodes.
+          visited = extended.visited;
+        }
+      } else if (canMoveBeyond.test(prevSideEffect)) {
+        // We can't extend beyond the aliasing node.
+        ret.add(prevSideEffect);
+      } else {
+        // The node doesn't alias, so we try its side-effecting parents.
+        Node prevMem = prevSideEffect.getPred(0);
+        Set<Node> finalVisited = visited;
+        seq(getPreviousSideEffectsOrPhis(prevMem))
+            .filter(n -> !finalVisited.contains(n))
+            .forEach(toVisit::add);
+      }
+
+      if (toVisit.size() > Math.max(MAX_NUMBER_OF_SYNC_PREDS, roots.size())) {
+        // This is a conservative default, to speed up compilation time and space.
+        return new LastAliasingSideEffectsResult(roots, originalVisited);
+      }
+    }
+    return new LastAliasingSideEffectsResult(ret, visited);
+  }
+
+  /**
+   * Filters out side effects from {@param sourceSuperset} which are already reachable through some
+   * other source in the set.
+   */
+  public static Set<Node> filterSideEffectSources(Set<Node> sourceSuperset) {
+    // We'll use the algorithm http://wiki.c2.com/?GraphSinkDetection.
+    // Note that we won't optimize beyond Phi nodes.
+    Set<Node> relevantNodes = reachableSideEffects(sourceSuperset);
+    Set<Node> possiblySources = new HashSet<>(relevantNodes);
+    for (Node n : relevantNodes) {
+      if (isSink(n)) {
+        continue;
+      }
+      // Any side effect with an incoming edge is not a source
+      getPrecedingSideEffects(n).forEach(possiblySources::removeAll);
+    }
+    return possiblySources;
+  }
+
+  private static boolean isSink(Node n) {
+    // We don't optimize beyond Phis.
+    return n.getOpCode() == ir_opcode.iro_Start;
+  }
+
+  private static Set<Node> reachableSideEffects(Set<Node> sources) {
+    Set<Node> reachable = new HashSet<>();
+    Deque<Node> toVisit = new ArrayDeque<>();
+    toVisit.addAll(sources);
+    while (!toVisit.isEmpty()) {
+      Node cur = toVisit.removeFirst();
+      if (reachable.contains(cur)) {
+        continue;
+      }
+      reachable.add(cur);
+      if (!isSink(cur)) {
+        getPrecedingSideEffects(cur).forEach(toVisit::addAll);
+      }
+    }
+    return reachable;
+  }
+
+  private static Seq<Set<Node>> getPrecedingSideEffects(Node n) {
+    Set<Node> mems;
+    if (n.getOpCode() == iro_Phi) {
+      // We have to be careful to not follow back edges. We might reach actual sources through
+      // them, so that they aren't sources anymore.
+      // So we only return those mems where the blocks aren't dominated by the Phi's.
+      Block phiBlock = (Block) n.getBlock();
+      mems =
+          seq(n.getPreds())
+              .filter(mem -> !Dominance.dominates(phiBlock, (Block) mem.getBlock()))
+              .toSet();
+    } else {
+      // Every other case is simple: Just use the single mem pred at index 0.
+      mems = Sets.newHashSet(n.getPred(0));
+    }
+
+    return seq(mems).map(SideEffects::getPreviousSideEffectsOrPhis);
+  }
+
+  /**
+   * Expects {@param modeM} to be a Mem node from which we follow mem edges until we hit a
+   * side-effect node (including Phis). Essentially skips uninteresting Proj M and Sync nodes.
+   */
+  public static Set<Node> getPreviousSideEffectsOrPhis(Node modeM) {
+    assert modeM.getMode().equals(Mode.getM());
+    switch (modeM.getOpCode()) {
+      case iro_Proj:
+        return Sets.newHashSet(modeM.getPred(0));
+      case iro_Phi:
+        return Sets.newHashSet(modeM); // we return Phis themselves
+      case iro_Sync:
+        Set<Node> ret = new HashSet<>();
+        seq(modeM.getPreds()).map(SideEffects::getPreviousSideEffectsOrPhis).forEach(ret::addAll);
+        return ret;
+      default:
+        LOGGER.warn("Didn't expect a mode M node " + modeM);
+        return Sets.newHashSet(modeM);
+    }
+  }
+
+  private static class LastAliasingSideEffectsResult {
+
+    public final Set<Node> sideEffects;
+    public final Set<Node> visited;
+
+    public LastAliasingSideEffectsResult(Set<Node> sideEffects, Set<Node> visited) {
+      this.sideEffects = sideEffects;
+      this.visited = visited;
+    }
+  }
+}


### PR DESCRIPTION
This means that equivalent loads have identical preds and can be removed
by CSE.

This PR drastically halves the number of Loads in the hot loop of `BigTensorProduct`. 