### PR TITLE
Deactivated Loop Invariant Code Motion again

### DIFF
--- a/src/main/java/minijava/Compiler.java
+++ b/src/main/java/minijava/Compiler.java
@@ -115,6 +115,7 @@ public class Compiler {
                 phiOptimizer,
                 aliasAnalyzer,
                 loadStoreOptimizer,
+                loopInvariantCodeMotion,
                 controlFlowOptimizer)
             .add(loadStoreOptimizer)
             .dependsOn(
@@ -142,8 +143,8 @@ public class Compiler {
                 loadStoreOptimizer)
             .add(aliasAnalyzer)
             .dependsOn() // It's quite expensive to run the alias analysis, so we do so only once.
-            .add(loopInvariantCodeMotion)
-            .dependsOn() // Dito
+            //.add(loopInvariantCodeMotion)
+            //.dependsOn() // Dito
             .build();
 
     ProgramMetrics metrics = ProgramMetrics.analyse(Program.getGraphs());

--- a/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
+++ b/src/main/java/minijava/ir/optimize/CommonSubexpressionElimination.java
@@ -72,7 +72,6 @@ public class CommonSubexpressionElimination extends BaseOptimizer {
     this.graph = graph;
     this.hashes.clear();
     this.similarNodes.clear();
-    // One postorder traversal should be enough, as we don't handle Phi nodes and thus cycles.
     fixedPointIteration(GraphUtils.topologicalOrder(graph));
     return transform();
   }


### PR DESCRIPTION
As it introduced reggressing performance due to introduced extra `Phi`s and back-edges.

No combination of only transforming leafs in the loop-nest tree and/or only tranforming each graph once yielded better performance than just leaving the optimization out. Bummer.

This PR brings a slight increase in performance though, due to the refactoring of the `PhiOptimizer` to make use of a more elaborate fixed-point iteration.