### PR TITLE
Reverted LoadStoreOptimizer.java

### DIFF
--- a/src/main/java/minijava/ir/optimize/LoadStoreOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/LoadStoreOptimizer.java
@@ -6,13 +6,15 @@ import firm.BackEdges;
 import firm.BackEdges.Edge;
 import firm.Graph;
 import firm.Mode;
+import firm.nodes.Block;
 import firm.nodes.Load;
 import firm.nodes.Node;
 import firm.nodes.Proj;
 import firm.nodes.Store;
+import java.util.List;
+import minijava.ir.Dominance;
 import minijava.ir.utils.GraphUtils;
 import minijava.ir.utils.NodeUtils;
-import org.jooq.lambda.Seq;
 
 public class LoadStoreOptimizer extends BaseOptimizer {
 
@@ -86,13 +88,24 @@ public class LoadStoreOptimizer extends BaseOptimizer {
         // We may only eliminate the store if it isn't visible any more, e.g. currentStore
         // is the only successor to previousStore.
         Node projOnPrevious = currentStore.getMem();
-        Seq<Edge> otherUsages =
-            seq(BackEdges.getOuts(projOnPrevious)).filter(be -> !be.node.equals(currentStore));
-        if (!otherUsages.isEmpty()) {
-          return;
+        List<Edge> usages =
+            seq(BackEdges.getOuts(projOnPrevious))
+                .filter(be -> !be.node.equals(currentStore))
+                .toList();
+        Block currentBlock = (Block) currentStore.getBlock();
+        boolean dominatesAllUsages =
+            seq(usages)
+                .allMatch(be -> Dominance.dominates(currentBlock, (Block) be.node.getBlock()));
+        if (!dominatesAllUsages) {
+          // We can't do the transformation, as the old stored value might leak through.
+          break;
         }
 
         hasChanged = true;
+        Proj projOnCurrent = NodeUtils.getMemProjSuccessor(currentStore);
+        for (Edge usage : usages) {
+          usage.node.setPred(usage.pos, projOnCurrent);
+        }
         currentStore.setMem(previousStore.getMem());
         Graph.killNode(previousStore);
         Graph.killNode(projOnPrevious);

--- a/src/main/java/minijava/ir/optimize/OptimizerFramework.java
+++ b/src/main/java/minijava/ir/optimize/OptimizerFramework.java
@@ -39,7 +39,7 @@ public class OptimizerFramework {
       toVisit.remove(next);
 
       Optimizer chosenOptimizer = idToOptimizers[next];
-      LOGGER.debug(chosenOptimizer.getClass().getSimpleName());
+      LOGGER.debug(chosenOptimizer.getClass().getSimpleName() + " on " + graph);
       Cli.dumpGraphIfNeeded(graph, "before-" + chosenOptimizer.getClass().getSimpleName());
       if (chosenOptimizer.optimize(graph)) {
         // The optimizer changed something, so we enqueue all dependent optimizers

--- a/src/main/java/minijava/ir/utils/GraphUtils.java
+++ b/src/main/java/minijava/ir/utils/GraphUtils.java
@@ -61,19 +61,17 @@ public class GraphUtils {
   }
 
   public static boolean areConnected(Node source, Node target) {
+    final boolean[] connected = {false};
     Consumer<Node> visitor =
         n -> {
           if (n.equals(target)) {
-            throw new EarlyExitException();
+            connected[0] = true;
           }
         };
 
-    try {
-      walkFromNodeDepthFirst(source, visitor, n -> {});
-      return false;
-    } catch (EarlyExitException e) {
-      return true;
-    }
+    walkFromNodeDepthFirst(source, visitor, n -> {});
+
+    return connected[0];
   }
 
   /**
@@ -186,6 +184,4 @@ public class GraphUtils {
   public static void reserveResource(Graph g, ir_resources_t resource) {
     binding_irgraph.ir_reserve_resources(g.ptr, resource.val);
   }
-
-  private static class EarlyExitException extends RuntimeException {}
 }

--- a/src/main/java/minijava/ir/utils/GraphUtils.java
+++ b/src/main/java/minijava/ir/utils/GraphUtils.java
@@ -61,17 +61,19 @@ public class GraphUtils {
   }
 
   public static boolean areConnected(Node source, Node target) {
-    final boolean[] connected = {false};
     Consumer<Node> visitor =
         n -> {
           if (n.equals(target)) {
-            connected[0] = true;
+            throw new EarlyExitException();
           }
         };
 
-    walkFromNodeDepthFirst(source, visitor, n -> {});
-
-    return connected[0];
+    try {
+      walkFromNodeDepthFirst(source, visitor, n -> {});
+      return false;
+    } catch (EarlyExitException e) {
+      return true;
+    }
   }
 
   /**
@@ -184,4 +186,6 @@ public class GraphUtils {
   public static void reserveResource(Graph g, ir_resources_t resource) {
     binding_irgraph.ir_reserve_resources(g.ptr, resource.val);
   }
+
+  private static class EarlyExitException extends RuntimeException {}
 }


### PR DESCRIPTION
… to the state of 5300473a88685cd2367a23fb2f1e8e865295476a, which should be correct in absence of Loop Invariant Code Motion (and also in presence, but LICM probably screwed something up).

Edit: Well, it wasn't. Now we're taking into account data dependencies on `store.getValue()` and thus should be fine, while still being able to perform the important transformations.