### PR TITLE
Various improvements to reliable compiler performance

### DIFF
--- a/src/main/java/minijava/ir/Dominance.java
+++ b/src/main/java/minijava/ir/Dominance.java
@@ -10,12 +10,26 @@ import java.util.Optional;
 import org.jooq.lambda.Seq;
 
 public class Dominance {
+  private static boolean needsToRecomputeDominance = false;
+  private static boolean needsToRecomputePostDominance = false;
+
+  public static void invalidateDominace() {
+    needsToRecomputeDominance = true;
+    needsToRecomputePostDominance = true;
+  }
+
   private static void computeDoms(Graph g) {
-    binding_irdom.compute_doms(g.ptr);
+    if (needsToRecomputeDominance) {
+      binding_irdom.compute_doms(g.ptr);
+      needsToRecomputeDominance = false;
+    }
   }
 
   private static void computePostDoms(Graph g) {
-    binding_irdom.compute_postdoms(g.ptr);
+    if (needsToRecomputePostDominance) {
+      binding_irdom.compute_postdoms(g.ptr);
+      needsToRecomputePostDominance = false;
+    }
   }
 
   private static void computeDomFrontiers(Graph g) {
@@ -59,5 +73,10 @@ public class Dominance {
 
   public static boolean strictlyPostDominates(Block dominator, Block dominated) {
     return !dominator.equals(dominated) && postDominates(dominator, dominated);
+  }
+
+  public static Block deepestCommonDominator(Block a, Block b) {
+    computeDoms(a.getGraph());
+    return new Block(binding_irdom.ir_deepest_common_dominator(a.ptr, b.ptr));
   }
 }

--- a/src/main/java/minijava/ir/optimize/AlgebraicSimplifier.java
+++ b/src/main/java/minijava/ir/optimize/AlgebraicSimplifier.java
@@ -1,6 +1,5 @@
 package minijava.ir.optimize;
 
-import static firm.bindings.binding_irnode.ir_opcode.iro_Minus;
 import static minijava.ir.utils.NodeUtils.asConst;
 
 import firm.Graph;
@@ -73,7 +72,7 @@ public class AlgebraicSimplifier extends BaseOptimizer {
     // Only rule we can make use of is associativity. For that we need the left arg to be Const
     // E.g. reassociate c_1 $ (c_2 $ x) = (c_1 $ c_2) $ x and let constant folding do the rest
     Optional<Const> first = asConst(node.getLeft());
-    if (first.isPresent() && node.getOpCode().equals(node.getRight().getOpCode())) {
+    if (first.isPresent() && node.getClass().equals(node.getRight().getClass())) {
       Binop right = (Binop) node.getRight();
       Optional<Const> second = asConst(right.getLeft());
       if (second.isPresent()) {
@@ -156,7 +155,7 @@ public class AlgebraicSimplifier extends BaseOptimizer {
 
     @Override
     public boolean isInverseNode(Node node) {
-      return node.getOpCode().equals(iro_Minus);
+      return node instanceof Minus;
     }
 
     @Override

--- a/src/main/java/minijava/ir/optimize/ConstantControlFlowOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/ConstantControlFlowOptimizer.java
@@ -29,7 +29,11 @@ public class ConstantControlFlowOptimizer extends BaseOptimizer {
   public boolean optimize(Graph graph) {
     this.graph = graph;
     hasChanged = false;
-    return fixedPointIteration(GraphUtils.reverseTopologicalOrder(graph));
+    hasChanged = fixedPointIteration(GraphUtils.reverseTopologicalOrder(graph));
+    if (hasChanged) {
+      Dominance.invalidateDominace();
+    }
+    return hasChanged;
   }
 
   @Override

--- a/src/main/java/minijava/ir/optimize/ConstantFolder.java
+++ b/src/main/java/minijava/ir/optimize/ConstantFolder.java
@@ -61,14 +61,12 @@ public class ConstantFolder extends BaseOptimizer {
   }
 
   private Optional<Node> getInputMem(Node node) {
-    switch (node.getOpCode()) {
-      case iro_Div:
-        return Optional.of(((Div) node).getMem());
-      case iro_Mod:
-        return Optional.of(((Mod) node).getMem());
-      default:
-        return Optional.empty();
+    if (node instanceof Div) {
+      return Optional.of(((Div) node).getMem());
+    } else if (node instanceof Mod) {
+      return Optional.of(((Mod) node).getMem());
     }
+    return Optional.empty();
   }
 
   private Optional<Proj> getOutputMemProj(Node node) {

--- a/src/main/java/minijava/ir/optimize/DuplicateProjDetector.java
+++ b/src/main/java/minijava/ir/optimize/DuplicateProjDetector.java
@@ -1,6 +1,5 @@
 package minijava.ir.optimize;
 
-import static firm.bindings.binding_irnode.ir_opcode.iro_Proj;
 import static minijava.ir.utils.GraphUtils.topologicalOrder;
 
 import firm.BackEdges;
@@ -22,7 +21,7 @@ public class DuplicateProjDetector extends BaseOptimizer {
   public void visit(Proj node) {
     // make sure there is no other Proj with the same num on the pred
     for (BackEdges.Edge be : BackEdges.getOuts(node.getPred())) {
-      if (be.node.getOpCode() != iro_Proj || be.node.equals(node)) {
+      if (!(be.node instanceof Proj) || be.node.equals(node)) {
         continue;
       }
       int num = ((Proj) be.node).getNum();

--- a/src/main/java/minijava/ir/optimize/JmpBlockRemover.java
+++ b/src/main/java/minijava/ir/optimize/JmpBlockRemover.java
@@ -11,6 +11,7 @@ import firm.nodes.Node;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import minijava.ir.Dominance;
 import minijava.ir.utils.FirmUtils;
 import minijava.ir.utils.GraphUtils;
 import minijava.ir.utils.NodeUtils;
@@ -70,6 +71,7 @@ public class JmpBlockRemover extends BaseOptimizer {
   // To implement this, the Phi nodes in the target block must also be adjusted.
   private void remove(Block redirected, Redirection redirection) {
     redirection.target.setPred(redirection.predIndex, redirection.source);
+    Dominance.invalidateDominace();
     Graph.killNode(redirected);
   }
 

--- a/src/main/java/minijava/ir/optimize/LoadStoreOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/LoadStoreOptimizer.java
@@ -33,94 +33,85 @@ public class LoadStoreOptimizer extends BaseOptimizer {
   @Override
   public void visit(Load node) {
     Node lastSideEffect = node.getMem().getPred(0);
-    switch (lastSideEffect.getOpCode()) {
-      case iro_Load:
-        // This will not happen any more. After the AliasAnalyzer, there shouldn't be any
-        // Load-Load dependencies. This case is thus handled by CSE.
-        // I leave it here anyway for when the alias analysis isn't run.
-        Load previousLoad = (Load) lastSideEffect;
-        if (!previousLoad.getPtr().equals(node.getPtr())) {
-          break;
-        }
+    if (lastSideEffect instanceof Load) {
+      // This will not happen any more. After the AliasAnalyzer, there shouldn't be any
+      // Load-Load dependencies. This case is thus handled by CSE.
+      // I leave it here anyway for when the alias analysis isn't run.
+      Load previousLoad = (Load) lastSideEffect;
+      if (!previousLoad.getPtr().equals(node.getPtr())) {
+        return;
+      }
 
-        hasChanged = true;
+      hasChanged = true;
 
-        // There must never be more than one Proj for each Num (e.g. M, Res, etc.),
-        // so we merge them.
-        NodeUtils.redirectProjsOnto(node, previousLoad);
-        Graph.killNode(node);
-        break;
-      case iro_Store:
-        Store previousStore = (Store) lastSideEffect;
-        if (!previousStore.getPtr().equals(node.getPtr())) {
-          break;
-        }
+      // There must never be more than one Proj for each Num (e.g. M, Res, etc.),
+      // so we merge them.
+      NodeUtils.redirectProjsOnto(node, previousLoad);
+      Graph.killNode(node);
+    } else if (lastSideEffect instanceof Store) {
+      Store previousStore = (Store) lastSideEffect;
+      if (!previousStore.getPtr().equals(node.getPtr())) {
+        return;
+      }
 
-        hasChanged = true;
-        for (BackEdges.Edge be : BackEdges.getOuts(node)) {
-          if (be.node.getMode().equals(Mode.getM())) {
-            // Let this Proj M point to the Store instead
-            be.node.setPred(be.pos, previousStore);
-            be.node.setBlock(previousStore.getBlock());
-          } else {
-            // And replace the data Projs by the stored value
-            Graph.exchange(be.node, previousStore.getValue());
-          }
+      hasChanged = true;
+      for (BackEdges.Edge be : BackEdges.getOuts(node)) {
+        if (be.node.getMode().equals(Mode.getM())) {
+          // Let this Proj M point to the Store instead
+          be.node.setPred(be.pos, previousStore);
+          be.node.setBlock(previousStore.getBlock());
+        } else {
+          // And replace the data Projs by the stored value
+          Graph.exchange(be.node, previousStore.getValue());
         }
-        NodeUtils.mergeProjsWithNum(previousStore, Store.pnM);
-        Graph.killNode(node);
-        break;
-      default:
-        break;
+      }
+      NodeUtils.mergeProjsWithNum(previousStore, Store.pnM);
+      Graph.killNode(node);
     }
   }
 
   @Override
   public void visit(Store currentStore) {
     Node lastSideEffect = currentStore.getMem().getPred(0);
-    switch (lastSideEffect.getOpCode()) {
-      case iro_Store:
-        Store previousStore = (Store) lastSideEffect;
-        if (!previousStore.getPtr().equals(currentStore.getPtr())) {
-          break;
-        }
+    if (lastSideEffect instanceof Store) {
+      Store previousStore = (Store) lastSideEffect;
+      if (!previousStore.getPtr().equals(currentStore.getPtr())) {
+        return;
+      }
 
-        // We may only eliminate the store if it isn't visible any more, e.g. currentStore
-        // is the only successor to previousStore.
-        Node projOnPrevious = currentStore.getMem();
-        List<Edge> otherUsages =
-            seq(BackEdges.getOuts(projOnPrevious))
-                .filter(be -> !be.node.equals(currentStore))
-                .toList();
-        Block currentBlock = (Block) currentStore.getBlock();
-        boolean dominatesAllUsages =
-            seq(otherUsages)
-                .allMatch(be -> Dominance.dominates(currentBlock, (Block) be.node.getBlock()));
-        if (!dominatesAllUsages) {
-          // We can't do the transformation, as the old stored value might leak through.
-          break;
-        }
+      // We may only eliminate the store if it isn't visible any more, e.g. currentStore
+      // is the only successor to previousStore.
+      Node projOnPrevious = currentStore.getMem();
+      List<Edge> otherUsages =
+          seq(BackEdges.getOuts(projOnPrevious))
+              .filter(be -> !be.node.equals(currentStore))
+              .toList();
+      Block currentBlock = (Block) currentStore.getBlock();
+      boolean dominatesAllUsages =
+          seq(otherUsages)
+              .allMatch(be -> Dominance.dominates(currentBlock, (Block) be.node.getBlock()));
+      if (!dominatesAllUsages) {
+        // We can't do the transformation, as the old stored value might leak through.
+        return;
+      }
 
-        // The value which we want to store might depend on some of the otherUsages, e.g.
-        // the result of a function call, in which case we can't do the transformation.
-        boolean anyDataDependency =
-            seq(otherUsages)
-                .anyMatch(be -> GraphUtils.areConnected(currentStore.getValue(), be.node));
-        if (anyDataDependency) {
-          break;
-        }
+      // The value which we want to store might depend on some of the otherUsages, e.g.
+      // the result of a function call, in which case we can't do the transformation.
+      boolean anyDataDependency =
+          seq(otherUsages)
+              .anyMatch(be -> GraphUtils.areConnected(currentStore.getValue(), be.node));
+      if (anyDataDependency) {
+        return;
+      }
 
-        hasChanged = true;
-        Proj projOnCurrent = NodeUtils.getMemProjSuccessor(currentStore);
-        for (Edge usage : otherUsages) {
-          usage.node.setPred(usage.pos, projOnCurrent);
-        }
-        currentStore.setMem(previousStore.getMem());
-        Graph.killNode(previousStore);
-        Graph.killNode(projOnPrevious);
-        break;
-      default:
-        break;
+      hasChanged = true;
+      Proj projOnCurrent = NodeUtils.getMemProjSuccessor(currentStore);
+      for (Edge usage : otherUsages) {
+        usage.node.setPred(usage.pos, projOnCurrent);
+      }
+      currentStore.setMem(previousStore.getMem());
+      Graph.killNode(previousStore);
+      Graph.killNode(projOnPrevious);
     }
   }
 }

--- a/src/main/java/minijava/ir/optimize/ProgramMetrics.java
+++ b/src/main/java/minijava/ir/optimize/ProgramMetrics.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import minijava.ir.emit.NameMangler;
 
 public class ProgramMetrics {
@@ -21,22 +22,70 @@ public class ProgramMetrics {
   public static ProgramMetrics analyse(Iterable<Graph> graphs) {
     ProgramMetrics metrics = new ProgramMetrics();
     for (Graph graph : graphs) {
-      metrics.updateGraphInfo(graph);
+      metrics.updateGraphInfoWithoutLoopBreakers(graph);
     }
+    metrics.detectLoopBreakers(graphs);
+
     return metrics;
   }
 
+  private void detectLoopBreakers(Iterable<Graph> graphs) {
+    Map<Graph, Integer> discovered = new HashMap<>();
+    Map<Graph, Integer> finished = new HashMap<>();
+    Set<Graph> visited = new HashSet<>();
+    int[] counter = new int[1];
+    counter[0] = 0;
+    for (Graph graph : graphs) {
+      visitCallGraphInPostorder(
+          graph, g -> discovered.put(g, counter[0]++), g -> finished.put(g, counter[0]++), visited);
+    }
+
+    // Now we can identify back edges
+    for (Graph graph : graphs) {
+      GraphInfo info = graphInfos.get(graph);
+      for (Graph call : info.calls) {
+        // Is this a back edge? It is if it's callee is a parent in the DFS tree.
+        boolean isParent =
+            discovered.get(call) <= discovered.get(graph)
+                && finished.get(call) >= finished.get(graph);
+        if (isParent) {
+          // This is a back edge. We update the graph info accordingly
+          // to mark it as a loop breaker.
+          graphInfos.put(graph, info.markedAsLoopBreaker());
+        }
+      }
+    }
+  }
+
   public void updateGraphInfo(Graph graph) {
+    updateGraphInfoWithoutLoopBreakers(graph);
+  }
+
+  private void updateGraphInfoWithoutLoopBreakers(Graph graph) {
     GraphWalker walker = new GraphWalker();
     graph.walk(walker);
-    graphInfos.put(graph, walker.resultSummary());
+    GraphInfo newInfo = walker.resultSummary();
+    GraphInfo oldInfo = graphInfos.get(graph);
+    if (oldInfo != null && oldInfo.isLoopBreaker) {
+      // We copy the old loop breaker info, so that we don't have to traverse
+      // the call graph too often.
+      newInfo = newInfo.markedAsLoopBreaker();
+    }
+    graphInfos.put(graph, newInfo);
   }
 
   public Set<Graph> reachableFromMain() {
+    return reachableFrom(main());
+  }
+
+  private static Graph main() {
+    return seq(Program.getGraphs()).filter(ProgramMetrics::isMain).findFirst().get();
+  }
+
+  private Set<Graph> reachableFrom(Graph graph) {
     Set<Graph> reachable = new HashSet<>();
     Set<Graph> toVisit = new HashSet<>();
-    Graph main = seq(Program.getGraphs()).filter(ProgramMetrics::isMain).findFirst().get();
-    toVisit.add(main);
+    toVisit.add(graph);
     while (!toVisit.isEmpty()) {
       Graph cur = toVisit.iterator().next();
       toVisit.remove(cur);
@@ -54,15 +103,38 @@ public class ProgramMetrics {
     return g.getEntity().getLdName().equals(NameMangler.mangledMainMethodName());
   }
 
+  private void visitCallGraphInPostorder(
+      Graph graph, Consumer<Graph> onDiscovery, Consumer<Graph> onFinish, Set<Graph> visited) {
+    if (visited.contains(graph)) {
+      return;
+    }
+
+    visited.add(graph);
+    onDiscovery.accept(graph);
+    GraphInfo info = graphInfos.get(graph);
+
+    for (Graph call : info.calls) {
+      visitCallGraphInPostorder(call, onDiscovery, onFinish, visited);
+    }
+
+    onFinish.accept(graph);
+  }
+
   public static class GraphInfo {
     public final Set<Graph> calls;
     public final boolean diverges;
     public final int size;
+    public final boolean isLoopBreaker;
 
-    public GraphInfo(Set<Graph> calls, boolean diverges, int size) {
+    public GraphInfo(Set<Graph> calls, boolean diverges, int size, boolean isLoopBreaker) {
       this.calls = calls;
       this.diverges = diverges;
       this.size = size;
+      this.isLoopBreaker = isLoopBreaker;
+    }
+
+    public GraphInfo markedAsLoopBreaker() {
+      return new GraphInfo(calls, diverges, size, true);
     }
   }
 
@@ -78,11 +150,8 @@ public class ProgramMetrics {
 
     @Override
     public void visit(End node) {
-      // The only possible (optional) predecessors for an end node are a Phi[loop] node at index 0, indicating
-      // a possibly diverging loop, and a to-be-kept-alive block at index 1.
-      //
-      // If a graph certainly diverges, its end node will have both predecessors (possibly more, I don't know).
-      diverges = node.getPredCount() >= 2;
+      // When the End block has no predecessors (e.g. Return nodes), the graph definitely diverges.
+      diverges = node.getBlock().getPredCount() == 0;
       super.visit(node);
     }
 
@@ -99,7 +168,7 @@ public class ProgramMetrics {
     }
 
     public GraphInfo resultSummary() {
-      return new GraphInfo(calls, diverges, size);
+      return new GraphInfo(calls, diverges, size, false);
     }
   }
 }

--- a/src/main/java/minijava/ir/optimize/SyncOptimizer.java
+++ b/src/main/java/minijava/ir/optimize/SyncOptimizer.java
@@ -7,6 +7,7 @@ import firm.Graph;
 import firm.nodes.Node;
 import firm.nodes.Sync;
 import java.util.Set;
+import minijava.ir.utils.FirmUtils;
 import minijava.ir.utils.GraphUtils;
 import minijava.ir.utils.NodeUtils;
 import minijava.ir.utils.SideEffects;
@@ -25,7 +26,7 @@ public class SyncOptimizer extends BaseOptimizer {
   public boolean optimize(Graph graph) {
     this.graph = graph;
     this.hasChanged = false;
-    GraphUtils.topologicalOrder(graph).forEach(this::visit);
+    FirmUtils.withBackEdges(graph, () -> GraphUtils.topologicalOrder(graph).forEach(this::visit));
     return hasChanged;
   }
 

--- a/src/main/java/minijava/ir/optimize/UnreachableCodeRemover.java
+++ b/src/main/java/minijava/ir/optimize/UnreachableCodeRemover.java
@@ -2,6 +2,7 @@ package minijava.ir.optimize;
 
 import firm.Graph;
 import firm.bindings.binding_irgopt;
+import minijava.ir.Dominance;
 
 public class UnreachableCodeRemover implements Optimizer {
 
@@ -17,6 +18,7 @@ public class UnreachableCodeRemover implements Optimizer {
 
     binding_irgopt.remove_bads(graph.ptr);
     // checking whether a change on the graph occurred doesn't seem to be possible
+    Dominance.invalidateDominace();
     return false;
   }
 }

--- a/src/main/java/minijava/ir/utils/ExtensionalEqualityComparator.java
+++ b/src/main/java/minijava/ir/utils/ExtensionalEqualityComparator.java
@@ -5,8 +5,6 @@ import com.sun.jna.Pointer;
 import firm.ArrayType;
 import firm.Mode;
 import firm.TargetValue;
-import firm.bindings.binding_irnode;
-import firm.bindings.binding_irnode.ir_opcode;
 import firm.nodes.Cmp;
 import firm.nodes.Const;
 import firm.nodes.Load;
@@ -45,15 +43,15 @@ public class ExtensionalEqualityComparator implements Comparator<Node> {
 
     Comparator<Node> constNodesLast =
         (a, b) -> {
-          if (a.getOpCode().equals(b.getOpCode())) {
+          if (a.getClass().equals(b.getClass())) {
             return 0;
           }
-          return a.getOpCode().equals(binding_irnode.ir_opcode.iro_Const) ? -1 : 1;
+          return a instanceof Const ? -1 : b instanceof Const ? 1 : 0;
         };
 
     Comparator<Node> predComparator =
         (a, b) -> {
-          if (a.getOpCode() == ir_opcode.iro_Phi) {
+          if (a instanceof Phi) {
             // We have to break loops here before we may access the preds.
             return a.getNr() - b.getNr();
           }
@@ -77,7 +75,7 @@ public class ExtensionalEqualityComparator implements Comparator<Node> {
 
     return Comparator.nullsFirst(
             constNodesLast
-                .thenComparing(Node::getOpCode)
+                .thenComparing(n -> n.getClass().getSimpleName())
                 .thenComparing(Node::getPredCount)
                 .thenComparingLong(n -> Pointer.nativeValue(n.getMode().ptr))
                 .thenComparing(predComparator)

--- a/src/main/java/minijava/ir/utils/GraphUtils.java
+++ b/src/main/java/minijava/ir/utils/GraphUtils.java
@@ -1,15 +1,11 @@
 package minijava.ir.utils;
 
-import static firm.bindings.binding_irnode.ir_opcode.iro_Block;
-import static firm.bindings.binding_irnode.ir_opcode.iro_Phi;
 import static org.jooq.lambda.tuple.Tuple.tuple;
 
 import firm.Graph;
 import firm.bindings.binding_irgraph;
 import firm.bindings.binding_irgraph.ir_resources_t;
-import firm.nodes.End;
-import firm.nodes.Node;
-import firm.nodes.Start;
+import firm.nodes.*;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -18,6 +14,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import minijava.ir.Dominance;
 import org.jooq.lambda.tuple.Tuple2;
 
 public class GraphUtils {
@@ -55,6 +52,9 @@ public class GraphUtils {
       for (int i = 0; i < n; ++i) {
         Node pred = copy.getPred(i);
         copy.setPred(i, copyNode(pred));
+      }
+      if (copy instanceof Block) {
+        Dominance.invalidateDominace();
       }
       return copy;
     }
@@ -148,7 +148,7 @@ public class GraphUtils {
 
       // we only add this node to the discovered set when it's a loop breaker.
       // This way, loops are always broken at what are back edges in the firm graph.
-      boolean isLoopBreaker = node.getOpCode() == iro_Block || node.getOpCode() == iro_Phi;
+      boolean isLoopBreaker = node instanceof Block || node instanceof Phi;
 
       if (counter < 0) {
         if (isLoopBreaker) {

--- a/src/main/java/minijava/ir/utils/SideEffects.java
+++ b/src/main/java/minijava/ir/utils/SideEffects.java
@@ -1,14 +1,14 @@
 package minijava.ir.utils;
 
 import static firm.bindings.binding_irnode.ir_opcode.iro_Phi;
-import static firm.bindings.binding_irnode.ir_opcode.iro_Start;
 import static org.jooq.lambda.Seq.seq;
 
 import com.google.common.collect.Sets;
 import firm.Mode;
-import firm.bindings.binding_irnode.ir_opcode;
 import firm.nodes.Block;
 import firm.nodes.Node;
+import firm.nodes.Phi;
+import firm.nodes.Start;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashSet;
@@ -70,12 +70,10 @@ public class SideEffects {
       }
       visited.add(prevSideEffect);
 
-      ir_opcode opCode = prevSideEffect.getOpCode();
-
-      if (opCode == iro_Start) {
+      if (prevSideEffect instanceof Start) {
         // We can't extend beyond a Start node.
         ret.add(prevSideEffect);
-      } else if (opCode == iro_Phi) {
+      } else if (prevSideEffect instanceof Phi) {
         // We try to extend beyond that Phi
         Set<Node> sideEffectsPrecedingPhi =
             seq(prevSideEffect.getPreds())
@@ -144,7 +142,7 @@ public class SideEffects {
 
   private static boolean isSink(Node n) {
     // We don't optimize beyond Phis.
-    return n.getOpCode() == ir_opcode.iro_Start;
+    return n instanceof Start;
   }
 
   private static Set<Node> reachableSideEffects(Set<Node> sources) {
@@ -166,7 +164,7 @@ public class SideEffects {
 
   private static Seq<Set<Node>> getPrecedingSideEffects(Node n) {
     Set<Node> mems;
-    if (n.getOpCode() == iro_Phi) {
+    if (n instanceof Phi) {
       // We have to be careful to not follow back edges. We might reach actual sources through
       // them, so that they aren't sources anymore.
       // So we only return those mems where the blocks aren't dominated by the Phi's.


### PR DESCRIPTION
- Identify loop breakers in the call graph which are never inlined
- Actually differentiate optimization levels (0 = only perform slight optimizations just before calling the backend, 1 = typical optimizations, 2 = also perform alias analysis)
- Recompute dominance only when necessary through explicit invalidation (huge boost)
- Use `instanceof` instead of `getOpcode()` in checks (moderate)
- Don't activate/deactivate out edges in hot spots (moderate)

This means much better worst case compiler performance, so that we should rarely time out.

I also tried to run the alias analysis after inlining only, but that didn't improve compiler performance as much as it slowed down produced code.

`-v 2` will now print performance statistics of each run optimization.